### PR TITLE
Tagmanager modification, allowing to extend Core tags from modules

### DIFF
--- a/application/libraries/Tagmanager.php
+++ b/application/libraries/Tagmanager.php
@@ -143,6 +143,7 @@ class TagManager
 		}
 		
 		
+		
 		/* If modules are installed : Get the modules tags definition
 		 * Modules tags definition must be stored in : /modules/your_module/libraires/tags.php
 		 * 
@@ -157,16 +158,34 @@ class TagManager
 				// Get tag definition class name
 				$methods = get_class_methods($class);
 				
+				// Get public vars
+				$vars = get_class_vars( $class );
+				
 				// Store tags definitions into self::$tags
 				// add module enclosing tag
 				self::$tags[$plugin] = $class.'::index';
 
+				
 				// Use of module name as namespace for the module to avoid modules tags collision
 				foreach ($methods as $method)
-				{
-					self::$tags[$plugin.':'.$method] = $class.'::'.$method;
+				{																
+					// Allow to extend core tags using "tag_extension_map" static array
+					
+					if (isset($vars["tag_extension_map"])&&isset($vars["tag_extension_map"][$method]))
+					{
+						self::$tags[$vars["tag_extension_map"][$method]] = $class.'::'.$method;
+					}
+					
+					
+					// Regular tag declaration					
+					else
+					{
+						self::$tags[$plugin.':'.$method] = $class.'::'.$method;
+					}
+
 				}
 				
+								
 				return true;
 			}
 			else


### PR DESCRIPTION
Tagmanager.php modification to allow modules to extend Core tags (articles, pages...).

You'll have to fill the "$tag_extension_map" array in the "libraries/tags.php" file of your module to define different tag mapping than the default one (which is "module_name:function_name").
