### PR TITLE
Defining constructor method properly

### DIFF
--- a/modules/Demo/controllers/admin/demo.php
+++ b/modules/Demo/controllers/admin/demo.php
@@ -13,7 +13,7 @@ class Demo extends Module_Admin
 	* @access	public
 	* @return	void
 	*/
-	public function construct()
+	public function __construct()
 	{
 	}
 


### PR DESCRIPTION
Added '__' before constructor name
