### PR TITLE
get_home_url() must always return the lang code in case of multiple lang...

### DIFF
--- a/application/libraries/Tagmanager.php
+++ b/application/libraries/Tagmanager.php
@@ -2572,11 +2572,7 @@ class TagManager
 
 		if (count(Settings::get_online_languages()) > 1 )
 		{
-			// if the current lang is the default one : don't return the lang code
-			if (Settings::get_lang() != Settings::get_lang('default'))
-			{
-				return base_url() . Settings::get_lang() .'/';
-			}
+			return base_url() . Settings::get_lang() .'/';
 		}
 
 		return base_url();


### PR DESCRIPTION
...uages

the get_home_url() function removes the lang code from url when the default language is selected. But when I don't specify a language url Ionize use the browser language... If I have english as Ionize default language and italian as browser language, browsing in english Ionize return in italian when I click on the logo with <a href="<ion:home_url />">... and it's not what I'm expecting. I propose to use always the lang code when online languages > 1
