### PR TITLE
Make modules use current backend language

### DIFF
--- a/application/controllers/admin/module.php
+++ b/application/controllers/admin/module.php
@@ -73,7 +73,7 @@ class Module extends MY_admin
 		// Loads module language file, if exists
 //		if (is_file($module_path.'language/'.$this->config->item('default_lang_code').'/'.$module_name.'_lang.php'))
 //		{
-			$this->lang->load($module_name, $this->config->item('default_lang_code'));
+			$this->lang->load($module_name, Settings::get_lang('current'));
 //		}
 //		else
 //		{


### PR DESCRIPTION
The modules used to use the sites default language for the translations `lang('something')`. With this fix, they should now use the current language.
