### PR TITLE
Fixed customfields checkbox default value handling

### DIFF
--- a/application/models/extend_field_model.php
+++ b/application/models/extend_field_model.php
@@ -198,10 +198,30 @@ class Extend_field_model extends Base_model
 			);
 			
 			// Checkboxes : first clear values from DB as the var isn't in $_POST if no value is checked
+			// furthermore, make sure that if all checkbox values are unchecked, we do not fallback to the
+			// default values, we do that by storing the special `-` value in the database. 
+			$langs = Settings::get_languages();
 			if ($extend_field['type'] == '4')
 			{
-				$this->{$this->db_group}->where($where);
-				$this->{$this->db_group}->delete($this->elements_table);			
+				if ($this->exists($where, $this->elements_table))
+				{
+					$this->{$this->db_group}->where($where);
+					$this->{$this->db_group}->update($this->elements_table, array('content' => '-'));
+				} else {
+					$data = array();
+					$data['content']      = '-';
+					$data['lang']         = '';
+					$data['id_parent']    = $id;
+					$data[$this->pk_name] = $extend_field[$this->pk_name];
+					if ($extend_field['translated'] != '1') {
+						$this->{$this->db_group}->insert($this->elements_table, $data);
+					} else {
+						foreach ($langs as $language) {
+							$data['lang'] = $language['lang'];
+							$this->{$this->db_group}->insert($this->elements_table, $data);
+						}
+					}
+				}
 			}
 			
 			// Get the value from _POST values and feed the data array

--- a/themes/admin/views/page/page.php
+++ b/themes/admin/views/page/page.php
@@ -165,8 +165,8 @@ if ($tracker_title == '')
 								<?php if ($extend_field['type'] == '4') :?>
 									
 									<?php
-										$pos = 		explode("\n", $extend_field['value']);
-										$saved = 	explode(',', $extend_field['content']);
+										$pos   = explode("\n", $extend_field['value']);
+										$saved = $extend_field['content'] != '-' ? explode(',', $extend_field['content']) : array();
 									?>
 									<?php
 										$i = 0; 


### PR DESCRIPTION
This patch tries to fix the following situation:

Currently it is not possible to set all of the checkboxes of a custom
fields to an unchecked state, if the default values for them are not
empty. Trying to do so, will cause the checkboxes to fallback to their
default value.
