### PR TITLE
Update system_check_model.php

### DIFF
--- a/application/models/system_check_model.php
+++ b/application/models/system_check_model.php
@@ -107,11 +107,11 @@ class System_check_model extends Base_model
 		$nb = 0;
 		
 		$sql = '
-			select id_article 
+			select id_article, main_parent
 			from page_article
-			where main_parent = 0
 			group by id_article
-			having COUNT(id_page) = 1
+			having count(id_page) = 1 and 
+			main_parent = 0
 		';
 		
 		$query = $this->{$this->db_group}->query($sql);


### PR DESCRIPTION
the check_article_context function doesn't work correctly because the sql query fetch also rows where an article has 2 page associations. In this case the routine set the main_parent flag to 1 for both rows, obtaining one article with 2 main parent page. I fixed it changing the sql. I tested it and it seems working fine.
