### PR TITLE
Saving an article without tags gives errors in PHP 5.14.7

### DIFF
--- a/application/models/tag_model.php
+++ b/application/models/tag_model.php
@@ -234,7 +234,7 @@ class Tag_model extends Base_model
 		if ($element && $id_element)
 		{
 			$data = array();
-			$tag_ids = explode(',', $tags);
+			$tag_ids = array_filter(explode(',', $tags), 'strlen');
 			$join_table = $element.'_tag';
 			$element_pk = 'id_'.$element;
 


### PR DESCRIPTION
Now filters out empty strings correctly so no empty tag value gets added.
