### PR TITLE
added Page.render.before event.

### DIFF
--- a/application/libraries/Tagmanager/Page.php
+++ b/application/libraries/Tagmanager/Page.php
@@ -128,6 +128,13 @@ class TagManager_Page extends TagManager
 		if ( ! empty($article))
 			self::register('article', $article);
 
+		// Event : On before render
+		$event_data = array(
+			'entity' => $entity,
+			'article' => $article
+		);
+		Event::fire('Page.render.before', $event_data);
+
 		self::$view = self::_get_page_view($page);
 
 		self::render();


### PR DESCRIPTION
I am coding an Ionize module which is supposed to restrict content access by regions. To achieve this, I needed the penetrate right before Tagmanager decides which content is going to be rendered.

"Ionize.front.load" couldn't (it fires the event before Tagmanager) helped me in this scenario, therefore I come with this patch.
