### PR TITLE
Fix for translated extended fields

### DIFF
--- a/application/models/base_model.php
+++ b/application/models/base_model.php
@@ -1696,6 +1696,10 @@ class Base_model extends CI_Model
 	 */
 	protected function add_extend_fields(&$data, $parent, $lang = NULL)
 	{
+		// fix for translated fields
+		if($lang == NULL)
+			$lang = Settings::get_lang('current');
+
 		// get the extend fields definition array
 		$efd = $this->get_extend_fields_definition($parent);
 


### PR DESCRIPTION
This fix provides proper lookup for translated extended fields content
(otherwise translated extended fields will never show up in the views).
