### PR TITLE
Fix lang_path in translation.php/_get_lang_files

### DIFF
--- a/application/controllers/admin/translation.php
+++ b/application/controllers/admin/translation.php
@@ -450,7 +450,7 @@ class Translation extends MY_admin
 						{
                     $lfiles[$type]['files'][] = array(
                         'path' => $lf,
-                        'lang_path' => str_replace($lang . DIRECTORY_SEPARATOR, '', $path),
+                        'lang_path' => preg_replace('/' . $lang . '\\' . DIRECTORY_SEPARATOR .'$/', '', $path),
                         'filename' => str_replace($path, '', $lf)
                     );
 						}


### PR DESCRIPTION
Fixed problem with broken lang_path.
If directory name contains translation language, then the language part removed from name and the module Static translations works wrong.
For example, path '/path/to/DOMAIN.ru/themes/adaptive/' was processed to '/path/to/DOMAIN.themes/adaptive/' and the module can't read files in hemes/adaptive/ru/anyfile_lang.php
