### PR TITLE
Fix file upload when memory_limit in php configured to have no limits.

### DIFF
--- a/application/libraries/Filemanager.php
+++ b/application/libraries/Filemanager.php
@@ -1417,7 +1417,8 @@ class FileManager
 		$max_upload = self::convert_size(ini_get('upload_max_filesize'));
 		$max_post = self::convert_size(ini_get('post_max_size'));
 		$memory_limit = self::convert_size(ini_get('memory_limit'));
-		if( $memory_limit < 0 ) {
+		if( $memory_limit < 0 )
+		{
 			$memory_limit = max($max_upload, $max_post);
 		}
 		$limit = min($max_upload, $max_post, $memory_limit);

--- a/application/libraries/Filemanager/Image.class.php
+++ b/application/libraries/Filemanager/Image.class.php
@@ -56,7 +56,7 @@ class Image {
 		$this->meta = self::checkFileForProcessing($file);
 
 		// only set the new memory limit of IMAGE_PROCESSING_MEMORY_MAX_USAGE MB when the configured one is smaller:
-		if ($this->meta['fileinfo']['memory_limit'] < IMAGE_PROCESSING_MEMORY_MAX_USAGE * 1024 * 1024)
+		if ($this->meta['fileinfo']['memory_limit'] > 0  &&  $this->meta['fileinfo']['memory_limit'] < IMAGE_PROCESSING_MEMORY_MAX_USAGE * 1024 * 1024)
 		{
 			ini_set('memory_limit', IMAGE_PROCESSING_MEMORY_MAX_USAGE . 'M'); //  handle large images
 		}
@@ -243,7 +243,7 @@ class Image {
 			throw new Exception('no_imageinfo');
 
 		// only set the new memory limit of IMAGE_PROCESSING_MEMORY_MAX_USAGE MB when the configured one is smaller:
-		if ($finfo['memory_limit'] < IMAGE_PROCESSING_MEMORY_MAX_USAGE * 1024 * 1024)
+		if ($finfo['memory_limit'] > 0  &&  $finfo['memory_limit'] < IMAGE_PROCESSING_MEMORY_MAX_USAGE * 1024 * 1024)
 		{
 			// recalc the 'will_fit' indicator now:
 			$finfo['will_fit'] = ($finfo['usage_min_advised'] < IMAGE_PROCESSING_MEMORY_MAX_USAGE * 1024 * 1024);

--- a/application/libraries/MY_Image_lib.php
+++ b/application/libraries/MY_Image_lib.php
@@ -335,6 +335,9 @@ class MY_Image_lib extends CI_Image_lib {
 		// Memory limit from php.ini config file in bytes
 		$ini_memory_limit = intval(substr(ini_get('memory_limit'), 0, -1)) * 1024 * 1024;
 
+		if ( $ini_memory_limit < 0 )
+			return true;
+
 		// First, check the source
 		$size = getimagesize($this->full_src_path);
 		$picture_need = $size[0]*$size[1]*(2.2+($truecolor*3)) + memory_get_usage();

--- a/application/libraries/MY_Upload.php
+++ b/application/libraries/MY_Upload.php
@@ -1193,6 +1193,10 @@ class MY_Upload extends CI_Upload
 		$max_upload = $this->convert_size(ini_get('upload_max_filesize'));
 		$max_post = $this->convert_size(ini_get('post_max_size'));
 		$memory_limit = $this->convert_size(ini_get('memory_limit'));
+		if($memory_limit<0)
+		{
+			$memory_limit = max($max_upload, $max_post);
+		}
 		$limit = min($max_upload, $max_post, $memory_limit);
 
 		return $limit;


### PR DESCRIPTION
When php configured to have no memory limit then memory_limit directive has value -1. We should keep in mind this behavior when calculating limits.
