### PR TITLE
Update media.php

### DIFF
--- a/application/controllers/admin/media.php
+++ b/application/controllers/admin/media.php
@@ -997,10 +997,10 @@ class Media extends MY_admin
         $expires = gmdate("D, d M Y H:i:s", time() + $expire) . " GMT";
         $size = strlen($content);
 
-        header("Content-Type: $mime");
-        header("Expires: $expires");
-        header("Cache-Control: max-age=$expire");
-        header("Content-Length: $size");
+        header("Content-Type: " . $mime);
+        header("Expires: " . $expires);
+        header("Cache-Control: max-age=" . $expire);
+        header("Content-Length: " . $size);
 
         echo $content;
         


### PR DESCRIPTION
This update will prevent some servers from sending thumbnails with broken headers to the admin panel, when viewing the media list attached to each page. 

If you host your Ionize project on certain servers, you are just not able to see thumbnails since they are sent as an AJAX response with bad headers.  

Believe me, at this moment, 50% of the servers I've worked with have this issue.
