### PR TITLE
Fixed calling non static Theme->output statically

### DIFF
--- a/application/core/MY_Controller.php
+++ b/application/core/MY_Controller.php
@@ -137,7 +137,8 @@ class MY_Controller extends CI_Controller
     	// Unique ID, useful for DOM Element displayed in windows.
     	$this->template['UNIQ'] = (uniqid());
 
-    	Theme::output($view, $this->template);
+	$theme = new Theme();
+	$theme->output($view, $this->template);
     }
 
 


### PR DESCRIPTION
Removing PHP error: 
Non-static method Theme::output() should not be called statically, assuming $this from incompatible context