### PR TITLE
Bugfix: JS error / Article edit view doesn't display media list

### DIFF
--- a/themes/admin/javascript/ionize/ionize_mediamanager.js
+++ b/themes/admin/javascript/ionize/ionize_mediamanager.js
@@ -42,7 +42,7 @@ var IonizeMediaManager = new Class(
 		this.parent =		options.parent;
 		this.filemanager =  null;
 
-		this.container = $(options.container);
+		this.container = $(options.container) ? $(options.container) : $('mediaContainer');
 
 		// Filemanager opening buttons
 		var self = this;


### PR DESCRIPTION
$(options.container) of mediamanager was not initialized - causing JavaScript error.
Solution: added $('mediaContainer') als default container when no container set in options.