### PR TITLE
Bugfix: CI delete_files()

### DIFF
--- a/system/helpers/file_helper.php
+++ b/system/helpers/file_helper.php
@@ -135,7 +135,7 @@ if ( ! function_exists('delete_files'))
 				if (is_dir($path.DIRECTORY_SEPARATOR.$filename))
 				{
 					// Ignore empty folders
-					if (substr($filename, 0, 1) != '.')
+//					if (substr($filename, 0, 1) != '.')
 					{
 						delete_files($path.DIRECTORY_SEPARATOR.$filename, $del_dir, $level + 1);
 					}


### PR DESCRIPTION
For example deleting all thumbs from the backend of ionize fails because of this bug in codeigniter (maybe a newer version of CI fixes this issue?)