### PR TITLE
Added condition: <ion:article:is_online>

### DIFF
--- a/application/libraries/Tagmanager/Article.php
+++ b/application/libraries/Tagmanager/Article.php
@@ -33,6 +33,7 @@ class TagManager_Article extends TagManager
 		'article:deny' => 			'tag_article_deny',
 
 		'article:is_active' => 		'tag_is_active',
+		'article:is_online' => 		'tag_is_online'
 	);
 
 
@@ -1138,8 +1139,37 @@ class TagManager_Article extends TagManager
 
 		return $return;
 	}
+	
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Condition on article being online or not. 
+	 * -Helpful eg. w/ custom article types that are online only in select languages
+	 *
+	 * Example usage:
+	 *
+	 * <ion:page:articles type="my-type">
+	 * 	<ion:article:is_online>
+	 *  		<ion:article>
+	 *  			article content rendering goes here...
+	 *  		</ion:article>
+	 *  	</ion:article:is_online>
+	 * </ion:page:articles>
+	 *
+	 * @param FTL_Binding $tag
+	 * @return string
+	 */
+	public static function tag_is_online(FTL_Binding $tag)
+	{
+		$article = $tag->get('article');
+
+		if ( $article['online'] )
+			return $tag->expand();
+
+		return '';
+	}
 
 }
 
 TagManager_Article::init();
-


### PR DESCRIPTION
This new article tag allows a condition on articles being online or not. 
I am not sure if there's a bug in the tag manager causing it to expand custom article types always (ignoring them being set "online" in the current language or not), or if the tag manager renders offline article's content only when they contain custom tags (as in my case) - anyway, this condition allows to check for articles being online and solve this problem.