### PR TITLE
Mocha toolbar- added handling for dyn. added events

### DIFF
--- a/themes/admin/javascript/mochaui/Controls/toolbar/toolbar.js
+++ b/themes/admin/javascript/mochaui/Controls/toolbar/toolbar.js
@@ -158,7 +158,7 @@ MUI.Toolbar = new NamedClass('MUI.Toolbar', {
 		var css = button.cssClass;
 		var where = Browser.name=='ie' ? 'top' : 'bottom';
 		var onclick = function(e){
-			if (e.stop) e.stop();
+			if (e && e.stop) e.stop();
 			var fireClick = true;
 			if (this.onClick) fireClick = this.onClick(this, self);
 			if (fireClick) self.fireEvent('click', [this,self]);


### PR DESCRIPTION
MochaUI toolbar _buildButton() otherwise throws a "TypeError: e is undefined" error when using dynamically installed click handlers (eg: $('someElement').addEvent('click', function () { /*...*/ }); )