### PR TITLE
Adapted mocha window decoration for mac

### DIFF
--- a/themes/admin/javascript/mochaui/Controls/window/window.js
+++ b/themes/admin/javascript/mochaui/Controls/window/window.js
@@ -1072,7 +1072,7 @@ MUI.Window.implement({
 
 		cache.title = new Element('span', {
 			'id': id + '_title',
-			'class': 'mochaTitle'
+			'class': 'mochaTitle ' + navigator.platform.toLowerCase()
 		}).inject(cache.titleBar);
 
 		if (options.icon){
@@ -1134,7 +1134,8 @@ MUI.Window.implement({
 		}
 
 		cache.controls = new Element('div', {
-			'id': id + '_controls'
+			'id': id + '_controls',
+			'class': navigator.platform.toLowerCase()
 		}).inject(cache.titleBar);
 
 		cache.footer = new Element('div', {

--- a/themes/admin/javascript/mochaui/Themes/ionize/css/window.css
+++ b/themes/admin/javascript/mochaui/Themes/ionize/css/window.css
@@ -34,9 +34,13 @@
 */
 .mochaTitlebar { width: 100%; overflow: hidden; background: url(../images/spacer.gif?from=fafafa&to=e5e5e5);}
 .mochaTitlebar .toolbar { padding-top:2px; padding-bottom:1px; padding-right:6px; margin-top:0; margin-bottom:0; height:23px; line-height:23px; float:right; vertical-align:middle; margin-right:0}
+.mochaTitlebar .toolbar.macintel { float:left; padding-left: 3px; }
 .mochaTitle { float:left; font-size: 12px; font-family: Arial,Helvetica,sans-serif; line-height: 23px; vertical-align:middle; font-weight: bold; margin: 0; padding: 0 10px 0 12px; color: #888; }
 .mochaTitle { color: #181818; }
+.mochaTitle.macintel { float: right; width: 50%; }
+
 .mochaTitlebar span.icon.windowMinimize { background: url('../images/window-minimize.gif') left top no-repeat; height:16px; width:16px;}
+.mochaTitlebar .macintel span.icon.windowMinimize { float: right; }
 .mochaTitlebar span.icon.windowMinimize:hover { border-color:transparent; }
 .mochaTitlebar span.icon.windowMaximize { background: url('../images/window-maximize.gif') left top no-repeat; height:16px; width:16px; }
 .mochaTitlebar span.icon.windowMaximize:hover { border-color:transparent; } 


### PR DESCRIPTION
MochaUI's window titlebar after this PR has a CSS classname from the client's platform, on Mac OS additional CSS styles than adapt the window decorations to the UI of Mac OS: window controls (close, minimize) are on the left of the titlebar and the title text is displayed horizontally centered.