### PR TITLE
ionize JS cleanup: reduced unnecessary temp. variables, added omitted…

### DIFF
--- a/themes/admin/javascript/ionize/ionize_authority.js
+++ b/themes/admin/javascript/ionize/ionize_authority.js
@@ -18,7 +18,7 @@ ION.Authority = new Class({
 	/**
 	 * All rules, by type
 	 */
-	all_rules: Array(),
+	all_rules: [],
 
 	has_all: false,
 
@@ -105,8 +105,7 @@ ION.Authority = new Class({
 	 *
 	 * @param action
 	 * @param resource
-	 * @param check_has_rule
-	 * @returns {boolean}
+	 * @returns {Boolean}
 	 *
 	 */
 	can:function(action, resource)
@@ -139,16 +138,14 @@ ION.Authority = new Class({
 
 	resourceHasRule: function(resource)
 	{
-		var has = false;
-
 		Object.each(ION.Authority.all_rules, function(rule)
 		{
 			if (resource == rule.resource)
 			{
-				has = true;
+				return true;
 			}
 		});
 
-		return has;
+		return false;
 	}
 });

--- a/themes/admin/javascript/ionize/ionize_button.js
+++ b/themes/admin/javascript/ionize/ionize_button.js
@@ -68,10 +68,7 @@ ION.ButtonToolbar = new Class({
 	 */
 	hasButton: function(id)
 	{
-		if (this.getButtonById(id) != null)
-			return true;
-
-		return false;
+		return (this.getButtonById(id) != null);
 	},
 
 	adopt:function(element)
@@ -215,7 +212,7 @@ ION.Button = new Class({
 					self.btnGroup.addClass('open');
 					self._correctBtnGroupPosition();
 				}
-			}
+			};
 
 			this.btnGroup.addEvent('click', this.options.onClick);
 
@@ -320,7 +317,7 @@ ION.Button = new Class({
 	 * Activates one button
 	 * (make it selected)
 	 *
-	 * @param args		String or Array of IDs. Partners to unactivate
+	 * @param args		String or Array of IDs. Partners to deactivate
 	 */
 	activate: function()
 	{

--- a/themes/admin/javascript/ionize/ionize_content.js
+++ b/themes/admin/javascript/ionize/ionize_content.js
@@ -12,11 +12,12 @@ ION.append({
 
 		if (typeOf(user) != 'null')
 		{
-			$('mainPanel').removeClass('bg-gray');
+			var elMainPanel = $('mainPanel');
+			elMainPanel.removeClass('bg-gray');
 			if (ION.grayPanels.contains(options.url) == true)
 				$('mainPanel').addClass('bg-gray');
 
-			$('mainPanel').getElements('iframe').each(function(el){el.destroy()});
+			elMainPanel.getElements('iframe').each(function(el){el.destroy()});
 
 			options.method = 'post';
 			options.url = ION.adminUrl + ION.cleanUrl(options.url);
@@ -41,7 +42,8 @@ ION.append({
 	initToolbox: function(toolbox_url, onContentLoaded, data)
 	{
 		// Creates the header toolbox if it doesn't exists
-		if ( ! $('mainPanel_headerToolbox')) {
+		var elMainPanelHeaderToolbox = $('mainPanel_headerToolbox');
+		if ( ! elMainPanelHeaderToolbox) {
 			this.panelHeaderToolboxEl = new Element('div', {
 				'id': 'mainPanel_headerToolbox',
 				'class': 'buttonbar'
@@ -64,7 +66,7 @@ ION.append({
 		}
 		else
 		{
-			$('mainPanel_headerToolbox').empty();
+			elMainPanelHeaderToolbox.empty();
 
 			if (typeOf(onContentLoaded) == 'function')
 				onContentLoaded($('mainPanel_headerToolbox'));
@@ -111,9 +113,9 @@ ION.append({
 	 */
 	initModuleToolbox: function(module, toolbox_url)
 	{
-
 		// Creates the header toolbox if it doesn't exists
-		if ( ! $('mainPanel_headerToolbox')) {
+		var elMainPanelHeaderToolbox = $('mainPanel_headerToolbox');
+		if ( ! elMainPanelHeaderToolbox) {
 			this.panelHeaderToolboxEl = new Element('div', {
 				'id': 'mainPanel_headerToolbox',
 				'class': 'panel-header-toolbox'
@@ -129,7 +131,7 @@ ION.append({
 		}
 		else
 		{
-			$('mainPanel_headerToolbox').empty();
+			elMainPanelHeaderToolbox.empty();
 		}
 	
 	},
@@ -215,7 +217,7 @@ ION.append({
 		if (cookieName)
 			disp = [Cookie.read(cookieName), disp].pick();
 			
-		var acc = new Fx.Accordion(togglers, elements, {
+		return new Fx.Accordion(togglers, elements, {
 			display: disp,
 			opacity: false,
 			alwaysHide: true,
@@ -230,8 +232,6 @@ ION.append({
 			},
 			duration:'short'
 		});
-		
-		return acc;
 	},
 
 	
@@ -333,7 +333,7 @@ ION.append({
 	/**
 	 * Updates multiple elements
 	 *
-	 * @param	array	Array of elements to update. Array('element_id' => 'url_to_call')
+	 * @param	{Array}		elements	Array of elements to update. Array('element_id' => 'url_to_call')
 	 *
 	 */
 	updateElements: function (elements)
@@ -358,9 +358,7 @@ ION.append({
 	 * Updates one / several DOM elements
 	 * based on one HTML Request result
 	 *
-	 * @param	Object	Options
-	 *					'url' : URL of the controller to call
-	 *					'element' : ID, selectors of the DOM element(s) to update
+	 * @param	{Object}	options		'url' : URL of the controller to call, 'element' : ID, selectors of the DOM element(s) to update
 	 *
 	 */
 	updateElement: function (options)
@@ -438,7 +436,8 @@ ION.append({
 	 * Originally using the Monkey Physics Datepicker.
 	 * Currently using this one : abidibo / mootools-datepicker
 	 *
-	 * @param	String		PHP Date format
+	 * @param	{String}	dateFormat		PHP Date format
+	 * @param	{Object}	options
 	 *
 	 */
 	initDatepicker: function(dateFormat, options)
@@ -506,15 +505,16 @@ ION.append({
 		{
 			item.addEvent('click', function(e)
 			{
+				var div;
 				if (document.selection)
 				{
-					var div = document.body.createTextRange();
+					div = document.body.createTextRange();
 					div.moveToElementText(item);
 					div.select();
 				}
 				else
 				{
-					var div = document.createRange();
+					div = document.createRange();
 					div.setStartBefore(item);
 					div.setEndAfter(item) ;
 					window.getSelection().addRange(div);
@@ -578,9 +578,10 @@ ION.append({
 	
 	/**
 	 * Init the dynamic title update
-	 * @param	string	Input source ID
-	 * @param	string	HTML Dom Element destination ID
-	 * @param	string	Lang code
+	 *
+	 * @param	{String}	source		Input source ID
+	 * @param	{String}	dest 		HTML Dom Element destination ID
+	 * @param	{String}	lang 		Lang code
 	 *
 	 */
 	initTitleUpdate: function(source, dest, lang)
@@ -617,8 +618,12 @@ ION.append({
 	{
 		if (src && dest)
 		{
-			if (typeOf(src) == 'string') {src = $(src)};
-			if (typeOf(dest) == 'string') {dest = $(dest)};
+			if (typeOf(src) == 'string') {
+				src = $(src);
+			}
+			if (typeOf(dest) == 'string') {
+				dest = $(dest);
+			}
 			
 			dest.set('html', src.value);
 		}
@@ -643,9 +648,9 @@ ION.append({
 	/**
 	 * Adds drag'n'drop functionnality to one element
 	 *
-	 * @param	HTML Dom Element	Element to add the drag on.
-	 * @param	String				CSS classes which can drop the element, comma separated names.
-	 * @param	String				Callback function(s), comma separated names.
+	 * @param	{Element} 	el 				Dom Element	Element to add the drag on.
+	 * @param	{String}	droppables		CSS classes which can drop the element, comma separated names.
+	 * @param	{String}	dropCallbacks	Callback function(s), comma separated names.
 	 *
 	 * @usage
 	 * 			ION.addDragDrop (item, '.dropcreators', 
@@ -837,10 +842,13 @@ ION.append({
 			});
 		});
 	},
-	
+
+	/**
+	 * @param	{String}	selector	element or sizzle path
+	 */
 	initClearField: function(selector)
 	{
-		var selector = typeOf(selector) == 'string' ? $(selector) : selector;
+		selector = typeOf(selector) == 'string' ? $(selector) : selector;
 
 		if (selector)
 		{
@@ -902,6 +910,7 @@ ION.append({
 		    relative: true,
 			selectMode : options.selectMode ? options.selectMode : false,
 			width: typeOf(options.width) != 'null' ? options.width : 'inherit',
+
 		    'injectChoice': function(choice)
 		    {
 				// choice is one <li> element
@@ -919,6 +928,7 @@ ION.append({
 				// add the mouse events to the <li> element
 				this.addChoiceEvents(choice);
 			},
+
 			onSelection: function(selection, item, value, input)
 			{
 				var id = item.getProperty('data-id');
@@ -1012,7 +1022,8 @@ ION.append({
 	/**
 	 * Adds the number of medias to the corresponding tab
 	 *
-	 *
+	 * @param	{String}	id_tab
+	 * @param	{String}	id_container
 	 */
 	updateTabNumber: function(id_tab, id_container)
 	{
@@ -1025,16 +1036,11 @@ ION.append({
 			if (tab.getElement('span')) tab.getElement('span').dispose();
 			
 			var ul = $(id_container).getElement('ul');
-			
-			if (typeOf(ul) != 'null')
-			{
-				nb = (ul.getChildren('li')).length;		
-			}
-			else
-			{
-				nb = ($(id_container).getChildren()).length;
-			}
-			
+
+			nb = (typeOf(ul) != 'null')
+				? (ul.getChildren('li')).length
+				: ($(id_container).getChildren()).length;
+
 			if (nb > 0)
 			{
 				tab.adopt(new Element('span', {'class':'tab-detail'}).set('html',nb));
@@ -1048,6 +1054,7 @@ ION.append({
 	 * Called after a delete by the controller if the element definition
 	 * has no more element for this parent.
 	 *
+	 * @param	{String}	id
 	 */
 	deleteTab: function(id)
 	{
@@ -1274,15 +1281,16 @@ ION.append({
 		
 		for (var i=0; i< order.length; i++)
 		{
+			var el;
 			if (articleContainer)
 			{
-				var el = articleContainer.getElement('li.article' + args.id_page + 'x' + order[i]);
+				el = articleContainer.getElement('li.article' + args.id_page + 'x' + order[i]);
 				el.inject(articleContainer, 'top');
 			}
 			
 			if (typeOf(articleList) != 'null')
 			{
-				var el = articleList.getElement('li.article' + args.id_page + 'x' + order[i]);
+				el = articleList.getElement('li.article' + args.id_page + 'x' + order[i]);
 				el.inject(articleList, 'top');
 			}
 		}
@@ -1291,10 +1299,11 @@ ION.append({
 	
 	/**
 	 * Links one article to a page
-	 * @param	int		ID of the article
-	 * @param	int		ID of the page to add as parent
-	 * @param	int		ID of the original page. 0 if no one.
-	 * @param	Event	Event object.
+	 *
+	 * @param	{Number}	id_article		ID of the article
+	 * @param	{Number}	id_page			ID of the page to add as parent
+	 * @param	{Number}	id_page_origin	ID of the original page. 0 if no one.
+	 * @param	{Event}		event			Event object.
 	 *
 	 */
 	linkArticleToPage: function(id_article, id_page, id_page_origin, event)
@@ -1356,10 +1365,12 @@ ION.append({
 	 * Reloads the page's articles list
 	 * called by ION.linkArticleToPage()
 	 *
+	 * @param	{String}	id_page
 	 */
 	reloadPageArticleList: function(id_page)
 	{
-		if (typeOf($('id_page')) != 'null' && $('id_page').value == id_page)
+		var elIdPage = $('id_page');
+		if (typeOf(elIdPage) != 'null' && elIdPage.value == id_page)
 		{
 			ION.HTML(ION.adminUrl + 'article/get_list', {'id_page':id_page}, {'update': 'articleListContainer'});
 		}
@@ -1444,11 +1455,10 @@ ION.append({
 	 * Link an Element to a parent
 	 * Called by ION.dropContentElementInPage(), ION.dropContentElementInArticle()
 	 *
-	 * @param	String			Parent type. Can be 'article', 'page', etc.
-	 * @param	DOM Element		The copied / moved element
-	 * @param	DOM Element		DOM target
-	 * @param	Event			Event
-	 *
+	 * @param	{String}	parent		Parent type. Can be 'article', 'page', etc.
+	 * @param	{Element}	element 	The copied / moved element
+	 * @param	{Element}	droppable	DOM target
+	 * @param	{Event}		event		Event
 	 */
 	dropContentElement: function(parent, element, droppable, event)
 	{
@@ -1485,6 +1495,9 @@ ION.append({
 	 * Drop one Content Element in a page (in the tree)
 	 * Copy / Move depending on the SHIFT key
 	 *
+	 * @param	{Element}	element
+	 * @param	{Element}	droppable
+	 * @param	{Event}		event
 	 */
 	dropContentElementInPage: function(element, droppable, event)
 	{
@@ -1496,6 +1509,9 @@ ION.append({
 	 * Drop one Content Element in an article (in the tree)
 	 * Copy / Move depending on the SHIFT key
 	 *
+	 * @param	{Element}	element
+	 * @param	{Element}	droppable
+	 * @param	{Event}		event
 	 */
 	dropContentElementInArticle: function(element, droppable, event)
 	{
@@ -1507,6 +1523,9 @@ ION.append({
 	/**
 	 * Drops an article into a page (from tree to page)
 	 *
+	 * @param	{Element}	element
+	 * @param	{Element}	droppable
+	 * @param	{Event}		event
 	 */
 	dropArticleInPage: function(element, droppable, event)
 	{
@@ -1522,6 +1541,9 @@ ION.append({
 	/**
 	 * Drops a page into an article (from tree to article's parents)
 	 *
+	 * @param	{Element}	element
+	 * @param	{Element}	droppable
+	 * @param	{Event}		event
 	 */
 	dropPageInArticle: function(element, droppable, event)
 	{
@@ -1531,6 +1553,11 @@ ION.append({
 	},
 
 
+	/**
+	 * @param	{String}	link_type
+	 * @param	{Element}	element
+	 * @param	{Element}	droppable
+	 */
 	dropElementAsLink: function(link_type, element, droppable)
 	{
 		// Target link rel
@@ -1561,7 +1588,9 @@ ION.append({
 	/**
 	 * Drops one article as link for another article / page
 	 *
-	 *
+	 * @param	{Element}	element
+	 * @param	{Element}	droppable
+	 * @param	{Event}		event
 	 */
 	dropArticleAsLink: function(element, droppable, event)
 	{
@@ -1572,7 +1601,9 @@ ION.append({
 	/**
 	 * Drops one page as link for another article / page
 	 *
-	 *
+	 * @param	{Element}	element
+	 * @param	{Element}	droppable
+	 * @param	{Event}		event
 	 */
 	dropPageAsLink: function(element, droppable, event)
 	{
@@ -1689,8 +1720,8 @@ ION.append({
 		var sep = arguments[2];
 		if ( ! sep) sep = '-';
 
-		var src = $(src);
-		var target = $(target);
+		src = $(src);
+		target = $(target);
 		
 		if (src && target)
 		{
@@ -1712,7 +1743,7 @@ ION.append({
 		var sep = arguments[1];
 		if ( ! sep) sep = '-';
 
-		var text = text.toLowerCase();
+		text = text.toLowerCase();
 
 		/*
 		text = text.replace(/ /g, '-');

--- a/themes/admin/javascript/ionize/ionize_core.js
+++ b/themes/admin/javascript/ionize/ionize_core.js
@@ -168,7 +168,7 @@ ION.append({
 		{
 			if ( ! self.isAssetPlanned(source))
 			{
-				sources.push(source)
+				sources.push(source);
 			}
 		});
 
@@ -328,6 +328,7 @@ ION.append({
 	/** 
 	 * Clears one form field
 	 *
+	 * @param	{String}	field
 	 */
 	clearField: function(field) 
 	{
@@ -338,12 +339,21 @@ ION.append({
 		}
 	},
 
+	/**
+	 * @param	{String} url
+	 * @returns {Boolean}
+	 */
 	checkUrl: function(url)
 	{
 		var RegexUrl = /(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/
 		return RegexUrl.test(url);
 	},
 
+	/**
+	 * @param	{String} selector
+	 * @param	{String} selectors
+	 * @param	{String} cl
+	 */
 	setSelected: function(selector, selectors, cl)
 	{
 		$$(selectors).each(function(el){
@@ -368,10 +378,12 @@ ION.append({
 	/**
 	 * Add one list of values to cookie
 	 *
+	 * @param {String} name
+	 * @param {String|number} value
 	 */
 	listAddToCookie: function(name, value)
 	{
-		var list = Array();
+		var list = [];
 		if (Cookie.read(name))
 			list = (Cookie.read(name)).split(',');
 		if (!list.contains(value))
@@ -385,10 +397,12 @@ ION.append({
 	/**
 	 * Remove one list of values from cookie
 	 *
+	 * @param	{String}		name
+	 * @param	{String|number} value
 	 */
 	listDelFromCookie: function(name, value)
 	{
-		var list = Array();
+		var list = [];
 		if (Cookie.read(name))
 			list = (Cookie.read(name)).split(',');
 		if (list.contains(value))
@@ -425,8 +439,7 @@ ION.append({
 			}
 		}
 
-		var options  =
-		{
+		return {
 			id: 'filemanagerWindow',
 			title: 'Media Manager',
 			container: document.body,
@@ -443,26 +456,20 @@ ION.append({
 				this.filemanager = null;
 			}
 		};
-
-		return options;
 	},
 
 	getWeekDayName: function(date)
 	{
-		if (typeOf(date) == 'date')
-			return Lang.get('day_' + date.getDay());
-		else
-			return '';
+		return (typeOf(date) == 'date')
+			? Lang.get('day_' + date.getDay())
+			: '';
 	},
 
 	getMonthName: function(date)
 	{
-		if (typeOf(date) == 'date')
-			return Lang.get('month_' + (date.getMonth() + 1));
-		else
-			return '';
-
-		return true;
+		return (typeOf(date) == 'date')
+			? Lang.get('month_' + (date.getMonth() + 1))
+			: '';
 	}
 });
 
@@ -484,7 +491,6 @@ Number.extend({
 	 * Returns a random number 
 	 * version: 1008.1718
 	 * discuss at: http://phpjs.org/functions/rand    // +   original by: Leslie Hoare
-	 *
 	 */
 	rand: function(min, max) {
 		var argc = arguments.length;
@@ -499,10 +505,8 @@ Number.extend({
 
 Number.extend({
 
-
 	round: function(num, dec) {
-		var result = Math.round( Math.round( num * Math.pow( 10, dec + 1 ) ) / Math.pow( 10, 1 ) ) / Math.pow(10,dec);
-		return result;
+		return Math.round( Math.round( num * Math.pow( 10, dec + 1 ) ) / Math.pow( 10, 1 ) ) / Math.pow(10,dec);
 	}
 
 });
@@ -530,7 +534,7 @@ Date.extend({
 			var t = d.split(/[- :]/);
 
 			// Apply each element to the Date function
-			var d = new Date(t[0], t[1]-1, t[2], t[3], t[4], t[5]);
+			d = new Date(t[0], t[1]-1, t[2], t[3], t[4], t[5]);
 
 			var h = d.getHours();
 			var m = d.getMonth();
@@ -596,15 +600,14 @@ Date.extend({
 
 	mysqlToUnix: function(date)
 	{
-		if (typeOf(date) != 'null')
-			return Math.floor(new Date(date.replace(' ', 'T')).getTime() / 1000);
-		else
-			return Math.floor(new Date('1970-01-01T01:00:00').getTime() / 1000);
+		return (typeOf(date) != 'null')
+			? Math.floor(new Date(date.replace(' ', 'T')).getTime() / 1000)
+			: Math.floor(new Date('1970-01-01T01:00:00').getTime() / 1000);
 	}
 });
 
 String.extend({
-	
+
 	htmlspecialchars_decode: function(text)
 	{
 		var tmp = new Element('span',{ 'html':text });
@@ -625,18 +628,15 @@ String.extend({
 			var specified = eval("["+arguments[2]+"]");
 			if(allowed)
 			{
-				var regex='</?(?!(' + specified.join('|') + '))\b[^>]*>';
-				html = html.replace(new RegExp(regex, 'gi'), '');
+				html = html.replace(new RegExp('</?(?!(' + specified.join('|') + '))\b[^>]*>', 'gi'), '');
 			}
 			else
 			{
-				var regex='</?(' + specified.join('|') + ')\b[^>]*>';
-				html = html.replace(new RegExp(regex, 'gi'), '');
+				html = html.replace(new RegExp('</?(' + specified.join('|') + ')\b[^>]*>', 'gi'), '');
 			}
 		}
 
-		var clean_string = html;
-		return clean_string;
+		return html;
 	},
 
 	capitalize: function(text)
@@ -728,10 +728,10 @@ Object.append(Element.NativeEvents, {
 		key_access: /^\.([a-z_][a-z_\d]*)/i,
 		index_access: /^\[(\d+)\]/,
 		sign: /^[\+\-]/
-	}
+	};
 
 	function sprintf() {
-		var key = arguments[0], cache = sprintf.cache
+		var key = arguments[0], cache = sprintf.cache;
 		if (!(cache[key] && cache.hasOwnProperty(key))) {
 			cache[key] = sprintf.parse(key)
 		}
@@ -741,14 +741,14 @@ Object.append(Element.NativeEvents, {
 	sprintf.format = function(parse_tree, argv) {
 		var cursor = 1, tree_length = parse_tree.length, node_type = "", arg, output = [], i, k, match, pad, pad_character, pad_length, is_positive = true, sign = ""
 		for (i = 0; i < tree_length; i++) {
-			node_type = get_type(parse_tree[i])
+			node_type = get_type(parse_tree[i]);
 			if (node_type === "string") {
 				output[output.length] = parse_tree[i]
 			}
 			else if (node_type === "array") {
-				match = parse_tree[i] // convenience purposes only
+				match = parse_tree[i]; // convenience purposes only
 				if (match[2]) { // keyword argument
-					arg = argv[cursor]
+					arg = argv[cursor];
 					for (k = 0; k < match[2].length; k++) {
 						if (!arg.hasOwnProperty(match[2][k])) {
 							throw new Error(sprintf("[sprintf] property '%s' does not exist", match[2][k]))
@@ -777,53 +777,61 @@ Object.append(Element.NativeEvents, {
 
 				switch (match[8]) {
 					case "b":
-						arg = arg.toString(2)
-						break
+						arg = arg.toString(2);
+						break;
+
 					case "c":
-						arg = String.fromCharCode(arg)
-						break
+						arg = String.fromCharCode(arg);
+						break;
+
 					case "d":
-						arg = parseInt(arg, 10)
-						break
+						arg = parseInt(arg, 10);
+						break;
+
 					case "e":
-						arg = match[7] ? arg.toExponential(match[7]) : arg.toExponential()
-						break
+						arg = match[7] ? arg.toExponential(match[7]) : arg.toExponential();
+						break;
+
 					case "f":
-						arg = match[7] ? parseFloat(arg).toFixed(match[7]) : parseFloat(arg)
-						break
+						arg = match[7] ? parseFloat(arg).toFixed(match[7]) : parseFloat(arg);
+						break;
+
 					case "o":
-						arg = arg.toString(8)
-						break
+						arg = arg.toString(8);
+						break;
+
 					case "s":
-						arg = ((arg = String(arg)) && match[7] ? arg.substring(0, match[7]) : arg)
-						break
+						arg = ((arg = String(arg)) && match[7] ? arg.substring(0, match[7]) : arg);
+						break;
+
 					case "u":
-						arg = arg >>> 0
-						break
+						arg = arg >>> 0;
+						break;
+
 					case "x":
-						arg = arg.toString(16)
-						break
+						arg = arg.toString(16);
+						break;
+
 					case "X":
-						arg = arg.toString(16).toUpperCase()
+						arg = arg.toString(16).toUpperCase();
 						break
 				}
 				if (!is_positive || (re.number.test(match[8]) && match[3])) {
-					sign = is_positive ? "+" : "-"
+					sign = is_positive ? "+" : "-";
 					arg = arg.toString().replace(re.sign, "")
 				}
-				pad_character = match[4] ? match[4] == "0" ? "0" : match[4].charAt(1) : " "
-				pad_length = match[6] - (sign + arg).length
-				pad = match[6] ? str_repeat(pad_character, pad_length) : ""
+				pad_character = match[4] ? match[4] == "0" ? "0" : match[4].charAt(1) : " ";
+				pad_length = match[6] - (sign + arg).length;
+				pad = match[6] ? str_repeat(pad_character, pad_length) : "";
 				output[output.length] = match[5] ? sign + arg + pad : (pad_character == 0 ? sign + pad + arg : pad + sign + arg)
 			}
 		}
 		return output.join("")
-	}
+	};
 
-	sprintf.cache = {}
-
+	sprintf.cache = {};
 	sprintf.parse = function(fmt) {
-		var _fmt = fmt, match = [], parse_tree = [], arg_names = 0
+		var _fmt = fmt, match = [], parse_tree = [], arg_names = 0;
 		while (_fmt) {
 			if ((match = re.text.exec(_fmt)) !== null) {
 				parse_tree[parse_tree.length] = match[0]
@@ -833,70 +841,70 @@ Object.append(Element.NativeEvents, {
 			}
 			else if ((match = re.placeholder.exec(_fmt)) !== null) {
 				if (match[2]) {
-					arg_names |= 1
-					var field_list = [], replacement_field = match[2], field_match = []
+					arg_names |= 1;
+					var field_list = [], replacement_field = match[2], field_match = [];
 					if ((field_match = re.key.exec(replacement_field)) !== null) {
-						field_list[field_list.length] = field_match[1]
+						field_list[field_list.length] = field_match[1];
 						while ((replacement_field = replacement_field.substring(field_match[0].length)) !== "") {
 							if ((field_match = re.key_access.exec(replacement_field)) !== null) {
-								field_list[field_list.length] = field_match[1]
+								field_list[field_list.length] = field_match[1];
 							}
 							else if ((field_match = re.index_access.exec(replacement_field)) !== null) {
-								field_list[field_list.length] = field_match[1]
+								field_list[field_list.length] = field_match[1];
 							}
 							else {
-								throw new SyntaxError("[sprintf] failed to parse named argument key")
+								throw new SyntaxError("[sprintf] failed to parse named argument key");
 							}
 						}
 					}
 					else {
-						throw new SyntaxError("[sprintf] failed to parse named argument key")
+						throw new SyntaxError("[sprintf] failed to parse named argument key");
 					}
-					match[2] = field_list
+					match[2] = field_list;
 				}
 				else {
 					arg_names |= 2
 				}
 				if (arg_names === 3) {
-					throw new Error("[sprintf] mixing positional and named placeholders is not (yet) supported")
+					throw new Error("[sprintf] mixing positional and named placeholders is not (yet) supported");
 				}
 				parse_tree[parse_tree.length] = match
 			}
 			else {
-				throw new SyntaxError("[sprintf] unexpected placeholder")
+				throw new SyntaxError("[sprintf] unexpected placeholder");
 			}
-			_fmt = _fmt.substring(match[0].length)
+			_fmt = _fmt.substring(match[0].length);
 		}
 		return parse_tree
-	}
+	};
 
 	var vsprintf = function(fmt, argv, _argv) {
-		_argv = (argv || []).slice(0)
-		_argv.splice(0, 0, fmt)
-		return sprintf.apply(null, _argv)
-	}
+		_argv = (argv || []).slice(0);
+		_argv.splice(0, 0, fmt);
+		return sprintf.apply(null, _argv);
+	};
 
 	/**
 	 * helpers
 	 */
 	function get_type(variable) {
-		return Object.prototype.toString.call(variable).slice(8, -1).toLowerCase()
+		return Object.prototype.toString.call(variable).slice(8, -1).toLowerCase();
 	}
 
 	function str_repeat(input, multiplier) {
-		return Array(multiplier + 1).join(input)
+		return Array(multiplier + 1).join(input);
 	}
 
 	/**
 	 * export to either browser or node.js
 	 */
 	if (typeof exports !== "undefined") {
-		exports.sprintf = sprintf
-		exports.vsprintf = vsprintf
+		exports.sprintf = sprintf;
+		exports.vsprintf = vsprintf;
 	}
 	else {
-		window.sprintf = sprintf
-		window.vsprintf = vsprintf
+		window.sprintf = sprintf;
+		window.vsprintf = vsprintf;
 
 		if (typeof define === "function" && define.amd) {
 			define(function() {
@@ -907,7 +915,7 @@ Object.append(Element.NativeEvents, {
 			})
 		}
 	}
-})(typeof window === "undefined" ? this : window)
+})(typeof window === "undefined" ? this : window);
 
 
 String.prototype.trimLeft = function(charlist) {

--- a/themes/admin/javascript/ionize/ionize_droppable.js
+++ b/themes/admin/javascript/ionize/ionize_droppable.js
@@ -12,7 +12,7 @@ ION.Droppable = new Class({
 	{
 		this.setOptions(options);
 		
-		var options = this.options;
+		options = this.options;
 		
 		/* Add focus in/out and blur events only if input has not the ".nofocus" class
 		 *

--- a/themes/admin/javascript/ionize/ionize_extendmanager.js
+++ b/themes/admin/javascript/ionize/ionize_extendmanager.js
@@ -12,7 +12,7 @@ ION.ExtendManager = new Class({
 
 	/**
 	 *
-	 * @param options
+	 * @param	{Object}	options
 	 */
 	initialize: function()
 	{
@@ -42,7 +42,7 @@ ION.ExtendManager = new Class({
 		this.w =            null;       // window
 		this.wContainer =   null;       // Items container (in window)
 		this.destination =  null;       // Destination container (ID) : TabSwapper only for the moment
-		this.destinationTitle = null    // Destination container title : Tab title only for the moment
+		this.destinationTitle = null;   // Destination container title : Tab title only for the moment
 
 		// Data posted by getWindowExtendListContent()
 		this.post = null;
@@ -71,12 +71,12 @@ ION.ExtendManager = new Class({
 	/**
 	 * Initialize basis properties
 	 *
-	 * @param options
+	 * @param	{Object}	options
 	 */
-	init: function(opt)
+	init: function(options)
 	{
 		var self = this,
-			opt = typeOf(opt) != 'null' ? opt : {};
+			opt = typeOf(options) != 'null' ? options : {};
 
 		this.post = null;
 		if (opt.context) this.context = opt.context;
@@ -108,7 +108,7 @@ ION.ExtendManager = new Class({
 	/**
 	 * Opens New Extend Window
 	 *
-	 * @param Object 	{
+	 * @param {Object} 	{
 	 * 						parent: 'contact',
 	 * 						id_parent: null,
 	 * 						onSuccess: function(json, this){}
@@ -172,7 +172,7 @@ ION.ExtendManager = new Class({
 	 * Extend Definition Edition
 	 * Opens Extend field definition Editor window
 	 *
-	 * @param id
+	 * @param	{String}	id
 	 */
 	editExtend: function(id)
 	{
@@ -212,6 +212,9 @@ ION.ExtendManager = new Class({
 		);
 	},
 
+	/**
+	 * @param	{Object}	extend
+	 */
 	delete: function(extend)
 	{
 		var options = typeOf(arguments[1]) != 'null' ? arguments[1] : {};
@@ -753,10 +756,7 @@ ION.ExtendManager = new Class({
 	 * linked to one context
 	 * and to one parent
 	 *
-	 * @param options	if 'onSucess' is set in options, this method will be called.
-	 * 					{
-	 * 						onSuccess: function(extends)
-	 * 					}
+	 * @param	{Object}	[options]	{ onSuccess: function(extends) }	if 'onSuccess' is set in options, this method will be called.
 	 */
 	getContextInstances: function()
 	{
@@ -793,12 +793,9 @@ ION.ExtendManager = new Class({
 
 
 	/**
-	 * Get Extend fileds definitions for one parent type.
+	 * Get Extend field definitions for one parent type.
 	 *
-	 * @param options	if 'onSucess' is set in options, this method will be called.
-	 * 					{
-	 * 						onSuccess: function(extends)
-	 * 					}
+	 * @param	{Object}	[options]		{ onSuccess: function(extends) }	if 'onSuccess' is set in options, this method will be called.
 	 */
 	getParentDefinitions: function()
 	{

--- a/themes/admin/javascript/ionize/ionize_extendmediamanager.js
+++ b/themes/admin/javascript/ionize/ionize_extendmediamanager.js
@@ -136,10 +136,11 @@ ION.ExtendMediaManager = new Class({
 	{
 		var self = this;
 
-		if ($('filemanagerWindow'))
+		var elFilemanagerWindow = $('filemanagerWindow');
+		if (elFilemanagerWindow)
 		{
 			// Window
-			var inst = $('filemanagerWindow').retrieve('instance');
+			var inst = elFilemanagerWindow.retrieve('instance');
 
 			// FM instance
 			this.filemanager = inst.filemanager;
@@ -233,12 +234,7 @@ ION.ExtendMediaManager = new Class({
 	 * Loads a media list through XHR regarding its type
 	 * called after a media list loading through 'loadList'
 	 *
-	 * @param options  Object {
-	 *                     parent:
-	 *                     id_parent:
-	 *                     id_extend:
-	 *                     lang:
-	 *                 }
+	 * @param	{Object}	options  Object		{ parent: ..., id_parent: ..., id_extend: ..., lang: ... }
 	 */
 	loadList: function()
 	{
@@ -261,7 +257,7 @@ ION.ExtendMediaManager = new Class({
 	 * Initiliazes the media list regarding to its type
 	 * called after a media list loading through 'loadList'
 	 *
-	 * @param responseJSON  JSON response object.
+	 * @param	responseJSON  JSON response object.
 	 *                      responseJSON.type : media type. Can be 'picture', 'video', 'music', 'file'
 	 */
 	completeLoadList: function(responseJSON)
@@ -372,7 +368,7 @@ ION.ExtendMediaManager = new Class({
 		var sortableOrder = this.mediaContainer.retrieve('sortableOrder');
 
 		// Remove "undefined" from serialized, which can comes from the clone.
-		var serie = new Array();
+		var serie = [];
 		serialized.each(function(item)
 		{
 			if (typeOf(item) != 'null')	serie.push(item);
@@ -444,8 +440,11 @@ ION.ExtendMediaManager = new Class({
 	/**
 	 * Unlink one media from his parent
 	 *
-	 * @param type  Media type
-	 * @param id    Media ID
+	 * @param	{String}	id_media    Media ID
+	 * @param	{Element}	parent
+	 * @param	{String}	id_parent
+	 * @param	{String}	id_extend
+	 * @param	{String}	lang
 	 */
 	detachMedia: function(id_media, parent, id_parent, id_extend, lang)
 	{

--- a/themes/admin/javascript/ionize/ionize_forms.js
+++ b/themes/admin/javascript/ionize/ionize_forms.js
@@ -26,18 +26,13 @@ ION.append({
 	/**
 	 * Get the associated form object and send it directly
 	 *
-	 * @param	string		URL to send the form data
-	 * @param	string		Element to update
-	 * @param	string		Element update URL
+	 * @param	{String}	url		URL to send the form data
+	 * @param	{String}	form	Element to update
 	 */
 	sendForm: function(url, form)
 	{
-		if (!form) {
-			form = '';
-		}
-		else {
-			form = $(form);
-		}
+		form = !form ? '' : $(form);
+
 		ION.updateRichTextEditors();
 
 		new Request.JSON(ION.getJSONRequestOptions(url, form)).send();
@@ -46,9 +41,8 @@ ION.append({
 	/**
 	 * Get the associated form object and send attached data directly
 	 *
-	 * @param	string		URL to send the form data
-	 * @param	string		Element to update
-	 * @param	string		Element update URL
+	 * @param	{String}	url		URL to send the form data
+	 * @param	{String}	data	Element to update
 	 */
 	sendData: function(url, data)
 	{
@@ -61,12 +55,13 @@ ION.append({
 	/**
 	 * Set an XHR action to a form and add click event to the given element
 	 *
-	 * @param	string	form ID
-	 * @param	string	element on wich attach the action (ID)
-	 * @param	string	action URL (with or without the base URL prefix)
-	 * @param	object	Confirmation object	{message: 'The confirmation question'}
-	 *
-	 */
+	 * @param	{String}	form ID
+	 * @param	{String}	button		element on which attach the action (ID)
+	 * @param	{String}	url			action URL (with or without the base URL prefix)
+	 * @param	{Object}	confirm		Confirmation object	{message: 'The confirmation question'}
+	 * @param	{Object}	options
+	 *{
+	} */
 	setFormSubmit: function(form, button, url, confirm, options)
 	{
 		if (typeOf($(form))!='null' && typeOf($(button)) != 'null')

--- a/themes/admin/javascript/ionize/ionize_itemsmanager.js
+++ b/themes/admin/javascript/ionize/ionize_itemsmanager.js
@@ -270,18 +270,18 @@ ION.ItemManager = new Class({
 		var sortableOrder = this.container.retrieve('sortableOrder');
 
 		// Remove "undefined" from serialized. Undefined comes from the clone, which isn't removed before serialize.
-		var serie = new Array();
+		var series = [];
 		serialized.each(function(item)
 		{
 			if (typeOf(item) != 'null')
-				serie.push(item);
+				series.push(item);
 		});
 
 		// If current <> new ordering : Save it ! 
-		if (sortableOrder.toString() != serie.toString() ) 
+		if (sortableOrder.toString() != series.toString() )
 		{
 			// Store the new ordering
-			this.container.store('sortableOrder', serie);
+			this.container.store('sortableOrder', series);
 
 			// Set the request URL
 			var url = this.adminUrl + this.options.controller + '/' + this.options.method;
@@ -297,7 +297,7 @@ ION.ItemManager = new Class({
 			{
 				url: url,
 				method: 'post',
-				data: 'order=' + serie,
+				data: 'order=' + series,
 				onSuccess: function(responseJSON, responseText)
 				{
 					MUI.hideSpinner();
@@ -315,7 +315,7 @@ ION.ItemManager = new Class({
 					// Success notification
 					if (responseJSON && responseJSON.message_type)
 					{
-						ION.notification.delay(50, MUI, new Array(responseJSON.message_type, responseJSON.message));
+						ION.notification.delay(50, MUI, [responseJSON.message_type, responseJSON.message]);
 					}
 				},
 				onFailure: this.failure.bind(this)

--- a/themes/admin/javascript/ionize/ionize_list.js
+++ b/themes/admin/javascript/ionize/ionize_list.js
@@ -172,8 +172,9 @@ ION.TableList = new Class({
 
 	/**
 	 *
-	 * @param item
-	 * @param c     Column option item
+	 * @param	{Object}	item
+	 * @param	{Object}	c     Column option item
+	 * @param	{String}	idx
 	 * @private
 	 */
 	_getItem: function(item, c, idx)
@@ -183,7 +184,7 @@ ION.TableList = new Class({
 
 		// Content
 		// Date format
-		var value = (c.key == '-rownum-') ? parseInt(idx) + 1 : (
+		var value = (c.key == '-rownum-') ? parseInt(idx, 10) + 1 : (
 						item[c.key] ? item[c.key] : (c.content ? c.content : '')
 					);
 
@@ -243,6 +244,7 @@ ION.TableList = new Class({
 			thead_tr = new Element('tr', {'class':'filters'}).inject(thead),
 			hash = ION.generateHash()
 		;
+		var i;
 
 		// Filters inputs
 		self.filter_inputs = [];
@@ -273,7 +275,7 @@ ION.TableList = new Class({
 					};
 
 					// Build the Extend
-					var i = self.extendManager.getExtendField(column.extend, options);
+					i = self.extendManager.getExtendField(column.extend, options);
 					i.setProperty('id', column.key + '_' + hash);
 
 					self.filter_inputs.push(i.getFormElement());
@@ -287,7 +289,7 @@ ION.TableList = new Class({
 				}
 				else
 				{
-					var i = new Element('input', {
+					i = new Element('input', {
 						type:    'text',
 						id: column.key + '_' + hash,
 						name:    column.key,
@@ -405,10 +407,11 @@ ION.TableList = new Class({
 
 	getSavedFilter: function()
 	{
-		var filters = ION.registry('filters'),
-			f = typeOf(filters[this.options.id]) == 'object' ? filters[this.options.id] : null;
+		var filters = ION.registry('filters');
 
-		return f;
+		return typeOf(filters[this.options.id]) == 'object'
+			? filters[this.options.id]
+			: null;
 	},
 
 
@@ -534,8 +537,7 @@ ION.List = new Class({
 
 
 	/**
-	 *
-	 * @param options
+	 * @param	{Object}	options
 	 */
 	initialize: function()
 	{
@@ -635,9 +637,10 @@ ION.List = new Class({
 			{
 				if (el.element)
 				{
+					var part;
 					if (typeOf(el.element) == 'function')
 					{
-						var part = el.element(item, li);
+						part = el.element(item, li);
 
 						if (typeOf(part) != 'null')
 						{
@@ -648,7 +651,7 @@ ION.List = new Class({
 					}
 					else
 					{
-						var part = new Element(el.element).inject(li);
+						part = new Element(el.element).inject(li);
 
 						// Left by default
 						if (el.class) part.addClass(el.class);

--- a/themes/admin/javascript/ionize/ionize_list_filter.js
+++ b/themes/admin/javascript/ionize/ionize_list_filter.js
@@ -99,7 +99,7 @@ ION.ListFilter = new Class({
 			var results = filtered;
 			
 			// Array of unique IDs of filtered notes (notes + class)
-			var notes_ids = new Array();
+			var notes_ids = [];
 			
 			results.each(function(item)
 			{

--- a/themes/admin/javascript/ionize/ionize_mediamanager.js
+++ b/themes/admin/javascript/ionize/ionize_mediamanager.js
@@ -175,7 +175,7 @@ var IonizeMediaManager = new Class(
 
 	
 	/**
-	 * Initiliazes the media list regarding to its type
+	 * Initializes the media list regarding to its type
 	 * called after a media list loading through 'loadMediaList'
 	 *
 	 * @param responseJSON  JSON response object.
@@ -273,7 +273,7 @@ var IonizeMediaManager = new Class(
 		var sortableOrder = this.container.retrieve('sortableOrder');
 
 		// Remove "undefined" from serialized. Undefined comes from the clone, which isn't removed before serialize.
-		var serie = new Array();
+		var serie = [];
 		serialized.each(function(item)
 		{
 			if (typeOf(item) != 'null')
@@ -387,7 +387,7 @@ var IonizeMediaManager = new Class(
 	/**
 	 * Opens fileManager
 	 *
-	 * @param options
+	 * @param	{Object}	options
 	 */
 	toggleFileManager:function()
 	{
@@ -399,9 +399,10 @@ var IonizeMediaManager = new Class(
 		else
 		{
 			// Exit if another fileManager is already running
-			if ($('filemanagerWindow'))
+			var elFilemanagerWindow = $('filemanagerWindow');
+			if (elFilemanagerWindow)
 			{
-				var inst = $('filemanagerWindow').retrieve('instance');
+				var inst = elFilemanagerWindow.retrieve('instance');
 
 				// Re-open window if minimized or shake if triing to open another FM
 				if (inst.isMinimized)
@@ -411,7 +412,7 @@ var IonizeMediaManager = new Class(
 				else
 				{
 					inst.focus();
-					$('filemanagerWindow').shake();
+					elFilemanagerWindow.shake();
 				}
 
 				return;

--- a/themes/admin/javascript/ionize/ionize_notify.js
+++ b/themes/admin/javascript/ionize/ionize_notify.js
@@ -155,10 +155,7 @@ ION.Notify = new Class({
 		// Resize the window... if window.
 		if (this.windowEl.retrieve('instance'))
 		{
-			if (mode == 'plus')
-				var newHeight = 	cs.y + bs.y + 10;
-			else
-				var newHeight = 	cs.y - bs.y + 10;
+			var newHeight = 	(mode == 'plus') ? (cs.y + bs.y + 10) : (cs.y - bs.y + 10);
 
 			this.windowEl.retrieve('instance').resize(
 			{
@@ -186,10 +183,9 @@ ION.Notify = new Class({
 
 	exists: function()
 	{
-		if (typeOf(this.options.type) != 'null')
-			var selector = 'div.contentNotify[data-type=' + this.options.type + ']';
-		else
-			var selector = 'div.contentNotify';
+		var selector = (typeOf(this.options.type) != 'null')
+			? 'div.contentNotify[data-type=' + this.options.type + ']'
+			: 'div.contentNotify';
 
 		var boxes = $$(selector),
 			box = null;
@@ -197,10 +193,9 @@ ION.Notify = new Class({
 		if (Object.getLength(boxes) > 0)
 			box = boxes[0];
 
-		if (box != null)
-			return box;
-
-		return false;
+		return (box != null)
+			? box
+			: false;
 	},
 
 	destroy: function()

--- a/themes/admin/javascript/ionize/ionize_panels.js
+++ b/themes/admin/javascript/ionize/ionize_panels.js
@@ -775,13 +775,14 @@ ION.MainPanel = new NamedClass('ION.MainPanel', {
 	_initToolbox: function()
 	{
 		// Creates the header toolbox if it doesn't exists
-		if ( ! $('mainPanel_headerToolbox')) {
+		var elMainPanelHeaderToolbox = $('mainPanel_headerToolbox');
+		if ( ! elMainPanelHeaderToolbox) {
 			new Element('div', {
 				'id': 'mainPanel_headerToolbox',
 				'class': 'buttonbar'
 			}).inject($('mainPanel_header'));
 		}
 
-		$('mainPanel_headerToolbox').empty();
+		elMainPanelHeaderToolbox.empty();
 	}
 });

--- a/themes/admin/javascript/ionize/ionize_request.js
+++ b/themes/admin/javascript/ionize/ionize_request.js
@@ -50,9 +50,8 @@ ION.append({
 	 */
 	initRequestEvent: function(item, url, data, options, mode)
 	{
-		var data = (typeOf(data) == 'null') ? {} : data;
-		
-		var mode = (typeOf(mode) == 'null') ? 'JSON' : mode;
+		data = (typeOf(data) == 'null') ? {} : data;
+		mode = (typeOf(mode) == 'null') ? 'JSON' : mode;
 
 		// Some safety before adding the event.
 		if (typeOf(item) == 'element')
@@ -148,11 +147,9 @@ ION.append({
 	 * 
 	 * @usage : No direct use. Use ION.JSON() instead.
 	 * 
-	 * @param	String		URL to send the form data. With or without the base URL prefix. Will be cleaned.
-	 * @param	Object		Form data to send as POST
-	 * @param	Object		Options
-	 *						'onSuccess' : Function to use as callback on success
-	 *
+	 * @param	{String}	url			URL to send the form data. With or without the base URL prefix. Will be cleaned.
+	 * @param	{Object}	data		Form data to send as POST
+	 * @param	{Object}	options		Options optionally containing 'onSuccess' : Function to use as callback on success
 	 */
 	getJSONRequestOptions: function(url, data, options)
 	{
@@ -211,7 +208,7 @@ ION.append({
 					if (responseJSON && typeOf(responseJSON.message_type) != 'null')
 					{
 						if (responseJSON.message_type != '')
-							ION.notification.delay(50, MUI, new Array(responseJSON.message_type, responseJSON.message));
+							ION.notification.delay(50, MUI, [responseJSON.message_type, responseJSON.message]);
 					}
 				},
 				onCancel: function()
@@ -244,12 +241,12 @@ ION.append({
 	 * 
 	 * @usage : No direct use. Use ION.HTML() instead.
 	 * 
-	 * @param	string		URL to send the form data. With or without the base URL prefix. Will be cleaned.
-	 * @param	mixed		Form data
-	 * @param	object		Options
-	 *						'update' : DOM Element ID to update with the result
-	 *						'append' : DOM Element ID to append the result to.
-	 *						'onSuccess' : Function to use as callback after success
+	 * @param	{String}	url		URL to send the form data. With or without the base URL prefix. Will be cleaned.
+	 * @param	{Mixed}		data 	Form data
+	 * @param	{Object}	options Options object, containing:
+	 *								'update' : DOM Element ID to update with the result
+	 *								'append' : DOM Element ID to append the result to.
+	 *								'onSuccess' : Function to use as callback after success
 	 *
 	 */
 	getHTMLRequestOptions: function(url, data, options)
@@ -303,7 +300,7 @@ ION.append({
 	 */
 	execCallbacks: function(args)
 	{
-		var callbacks = new Array();
+		var callbacks = [];
 
 		// More than one callback
 		if (typeOf(args) == 'array') {

--- a/themes/admin/javascript/ionize/ionize_select.js
+++ b/themes/admin/javascript/ionize/ionize_select.js
@@ -35,7 +35,7 @@ ION.Select = new Class({
 	{
 		this.setOptions(options);
 
-		this.storage = new Array();
+		this.storage = [];
 
 		return this.getHtml();
 	},

--- a/themes/admin/javascript/ionize/ionize_staticitemmanager.js
+++ b/themes/admin/javascript/ionize/ionize_staticitemmanager.js
@@ -388,26 +388,25 @@ ION.StaticItemManager = new Class({
 			new Element('h3', {'class':'toggler itemDefinition', html:Lang.get('ionize_title_item_fields')}).inject(container);
 
 			var divFields = new Element('div', {'class':'element itemDefinition'}).inject(container),
-				pFields = new Element('p', {'class':'h30'}).inject(divFields),
-				divFieldsContainer = new Element('div', {'class':'mb30'}).inject(divFields),
-				btnNewField = new ION.Button({
-					container: pFields,
-					title: Lang.get('ionize_label_add_field'),
-					'class': 'light right',
-					icon: 'icon-plus',
-					onClick: function()
-					{
-						self.extendManager.createExtend({
-							parent: 'item',
-							id_parent: item.id_item_definition,
-							onSuccess: function()
-							{
-								self._getDefinitionFieldList(item, divFieldsContainer);
-							}
-						});
-					}
-				});
-			;
+			pFields = new Element('p', {'class':'h30'}).inject(divFields),
+			divFieldsContainer = new Element('div', {'class':'mb30'}).inject(divFields),
+			btnNewField = new ION.Button({
+				container: pFields,
+				title: Lang.get('ionize_label_add_field'),
+				'class': 'light right',
+				icon: 'icon-plus',
+				onClick: function()
+				{
+					self.extendManager.createExtend({
+						parent: 'item',
+						id_parent: item.id_item_definition,
+						onSuccess: function()
+						{
+							self._getDefinitionFieldList(item, divFieldsContainer);
+						}
+					});
+				}
+			});
 
 			this._getDefinitionFieldList(item, divFieldsContainer);
 		}
@@ -831,7 +830,7 @@ ION.StaticItemManager = new Class({
 	/**
 	 * Delete one item instance
 	 *
-	 * @param id
+	 * @param	{Object}	item
 	 */
 	deleteItem: function(item)
 	{

--- a/themes/admin/javascript/ionize/ionize_stepswapper.js
+++ b/themes/admin/javascript/ionize/ionize_stepswapper.js
@@ -73,7 +73,7 @@ ION.StepSwapper = new Class({
 
 			if (idx <= (index-1))
 			{
-				var toset = parseInt(idx + 1)
+				var toset = parseInt(idx + 1, 10);
 				item.addEvent('click', function(){
 					self.click(toset);
 				});

--- a/themes/admin/javascript/ionize/ionize_tinymce.js
+++ b/themes/admin/javascript/ionize/ionize_tinymce.js
@@ -3,12 +3,12 @@ ION.append({
 	
 	tinyMceSettings: function(id, mode, options)
 	{
-		var options = (typeOf(options) != 'null') ? options : {};
+		options = (typeOf(options) != 'null') ? options : {};
 
 		var width = (typeOf(options.width) != 'null') ? options.width : '100%';
 		var height = (typeOf(options.height) != 'null') ? options.height : 180;
 
-		var spell_langs = new Array();
+		var spell_langs = [];
 		var idx = ([Cookie.read('articleTab'), false].pick());
 		if (typeOf(idx) == 'null')
 			idx = 0;
@@ -21,11 +21,12 @@ ION.append({
 			});
 		var spellchecker_languages = spell_langs.join();
 
+		var settings;
 		switch (mode)
 		{
 			case 'small':
 
-				var settings =  
+				settings =
 				{
 					mode : 'exact',
 					elements : id,
@@ -92,7 +93,7 @@ ION.append({
 				break;
 			
 			default:
-				var settings = {
+				settings = {
 					mode : 'exact',
 					elements : id,
 					theme : 'advanced',
@@ -204,16 +205,14 @@ ION.append({
 	
 	/**
 	 *
-	 * @param tab_selector          Each tab much have the "rel" attribute set. Example : rel="fr"
-	 * @param container_selector    textareas selector. Must have the same "rel" attr. as the atb.
-	 *                              Example : #categoryTabContent .tinyCategory
-	 * @param mode                  Editor mode. Can be 'small' or empty (normal editor)
-	 * @param options
+	 * @param	{String}	tab_selector          Each tab much have the "rel" attribute set. Example : rel="fr"
+	 * @param	{String}	container_selector    textareas selector. Must have the same "rel" attr. as the atb.	Example : #categoryTabContent .tinyCategory
+	 * @param	{String}	mode                  Editor mode. Can be 'small' or empty (normal editor)
+	 * @param	{Object}	options
 	 */
 	initTinyEditors: function(tab_selector, container_selector, mode, options)
 	{
 		var textareas = $$(container_selector);
-		var mode = mode;
 
 		if (typeOf(tab_selector) == 'null')
 		{
@@ -469,7 +468,7 @@ ION.append({
 		function getAttr(s, n) {
 			n = new RegExp(n + '=\"([^\"]+)\"', 'g').exec(s);
 			return n ? tinymce.DOM.decode(n[1]) : '';
-		};
+		}
 
 		return co.replace(/(?:<p[^>]*>)*(<img[^>]+>)(?:<\/p>)*/g, function(a,im) {
 			var cls = getAttr(im, 'class');
@@ -490,9 +489,7 @@ ION.append({
 
 			// Here : Get the media src by Ajax request
 
-			var image = 'files/pictures/IMG_8438.jpg';
-
-			return image;
+			return 'files/pictures/IMG_8438.jpg';
 		});
 	}
 

--- a/themes/admin/javascript/ionize/ionize_tracker.js
+++ b/themes/admin/javascript/ionize/ionize_tracker.js
@@ -77,7 +77,7 @@ Ionize.Tracker.append(
 
 	getDomEditedElements: function()
 	{
-		var domElements = new Array();
+		var domElements = [];
 		var elements = $$('.data-tracker');
 
 		elements.each(function(el)

--- a/themes/admin/javascript/ionize/ionize_tree.js
+++ b/themes/admin/javascript/ionize/ionize_tree.js
@@ -283,7 +283,7 @@ ION.PermissionTree = new Class({
 
 	get_rules_array:function()
 	{
-		var data = new Array();
+		var data = [];
 
 		if (this.options.rules)
 		{

--- a/themes/admin/javascript/ionize/ionize_tree_xhr.js
+++ b/themes/admin/javascript/ionize/ionize_tree_xhr.js
@@ -34,7 +34,7 @@ ION.TreeXhr = new Class({
 		this.mainpanel = ION.mainpanel;
 		
 		// Array of itemManagers
-		this.itemManagers = {'page': new Array(), 'article': new Array()};
+		this.itemManagers = {'page': [], 'article': []};
 		
 		this.elementIcon_Model = new Element('div', {'class': 'tree-img drag'});
 		this.plusMinus_Model = new Element('div', {'class': 'tree-img plus'});
@@ -45,7 +45,7 @@ ION.TreeXhr = new Class({
 		this.span_Model = new Element('span');
 		this.title_Model = new Element('a', {'class': 'title'});
 		
-		this.opened = new Array();
+		this.opened = [];
 		this.getOpenedFromCookie();
 
 		/*
@@ -510,8 +510,9 @@ ION.TreeXhr = new Class({
 			ION.listAddToCookie(this.id_container, folder.retrieve('id_page'));
 			this.getOpenedFromCookie();
 
-			$('btnStructureExpand').store('status', 'expand');
-			$('btnStructureExpand').value = Lang.get('ionize_label_collapse_all');
+			var elBtnStructureExpand = $('btnStructureExpand');
+			elBtnStructureExpand.store('status', 'expand');
+			elBtnStructureExpand.value = Lang.get('ionize_label_collapse_all');
 		}
 	},
 
@@ -603,12 +604,9 @@ ION.TreeXhr = new Class({
 		// Parent DOM Element (usually a folder LI)
 		var parentEl = this.id_container + '_page_' + id_parent;
 
-		if (typeOf($(parentEl)) == 'null')
-			parentEl = this.container;
-		else
-			parentEl = $(parentEl);
-
-		return parentEl;
+		return (typeOf($(parentEl)) == 'null')
+			? this.container
+			: $(parentEl);
 	},
 
 	/**
@@ -705,10 +703,9 @@ ION.TreeXhr = new Class({
 	 */
 	getOpenedFromCookie:function()
 	{
-		if (Cookie.read(this.id_container))
-			this.opened = (Cookie.read(this.id_container)).split(',');
-		else
-			this.opened = new Array();
+		this.opened = (Cookie.read(this.id_container))
+			? (Cookie.read(this.id_container)).split(',')
+			: [];
 	},
 
 	getResourceName: function(element, id, type)

--- a/themes/admin/javascript/ionize/ionize_ui.js
+++ b/themes/admin/javascript/ionize/ionize_ui.js
@@ -137,7 +137,7 @@ ION.UiElement = new Class({
 
 	getManageFieldList: function()
 	{
-		var self = this
+		var self = this;
 
 		ION.JSON(
 			ION.adminUrl + 'ui/get_element_fields',

--- a/themes/admin/javascript/ionize/ionize_window.js
+++ b/themes/admin/javascript/ionize/ionize_window.js
@@ -63,16 +63,17 @@ ION.Window = new Class({
 
 	/**
 	 *
-	 * @param options
+	 * @param	{Object}	options
 	 */
 	initialize: function()
 	{
 		var options = arguments[0] ? arguments[0] : {};
 		this.setOptions(options);
 
+		var self;
 		if (options.id && $(options.id))
 		{
-			var self = $(options.id).retrieve('ion_window');
+			self = $(options.id).retrieve('ion_window');
 
 			var w = self.getWindow();
 			w.focus.delay(10, w);
@@ -91,7 +92,7 @@ ION.Window = new Class({
 				this.w = this._createWindow(options);
 
 			// Once we have this.w, we can affect 'this' to all buttons
-			var self = this;
+			self = this;
 			this.buttons.each(function(button){
 				button.w = self;
 			});
@@ -349,9 +350,7 @@ ION.Window = new Class({
 
 		Object.append(opt, options);
 
-		var w = this._createWindow(opt);
-
-		return w;
+		return this._createWindow(opt);
 	}
 });
 
@@ -576,7 +575,7 @@ ION.append({
 			draggable: true,
 			y: 150,
 			padding: { top: 15, right: 15, bottom: 8, left: 15 }			
-		}
+		};
 
 		// Extends the window options
 		if (typeOf(wOptions) != 'null') {options =  Object.append(options, wOptions);}
@@ -611,11 +610,12 @@ ION.append({
 	 * Ionize generic form window
 	 * Use to load a window which contains a form 
 	 *
-	 * @param	string		Window ID.
-	 * @param	string		Window Form ID
-	 * @param	string		Lang translation key or string as title of the window
-	 * @param	string		URL called in case of form validation
-	 * @param	object		Window extended options
+	 * @param	{String}	id			Window ID.
+	 * @param	{String}	form		Window Form ID
+	 * @param	{String}	title		Lang translation key or string as title of the window
+	 * @param	{String}	wUrl		URL called in case of form validation
+	 * @param	{Object}	wOptions	Window extended options
+	 * @param	{Object}	data
 	 *
 	 */
 	formWindow: function(id, form, title, wUrl, wOptions, data)
@@ -685,7 +685,7 @@ ION.append({
 
 	/**
 	 * Opens a data window, without buttons
-	 * Usefull for editing a list
+	 * Useful for editing a list
 	 *
 	 */
 	dataWindow: function(id, title, wUrl, wOptions, data)
@@ -753,8 +753,15 @@ ION.append({
 		// Window creation
 		return new MUI.Window(options);
 	},
-	
 
+
+	/**
+	 *
+	 * @param	{String}	type
+	 * @param	{String}	msg
+	 * @returns {Object}
+	 * @private
+	 */
 	_getModalOptions: function(type, msg)
 	{
 		// Window message
@@ -780,7 +787,7 @@ ION.append({
 			resizable: true,
 			y: 150,
 			padding: { top: 15, right: 15, bottom: 8, left: 15 }			
-		}
+		};
 
 		// Event on btn No : Simply close the window
 		btnOk.addEvent('click', function() 
@@ -794,10 +801,10 @@ ION.append({
 	/**
 	 * Returns the buttons yes/no HTMLDOMElement
 	 *
-	 * @param	string		Window ID (to link with the close button)
-	 * @param	string		URL or Callback JS function to call if yes answer
-	 * @param	string		Element to update after url completion
-	 * @param	string		URL of the update element
+	 * @param	{String}	id			Window ID (to link with the close button)
+	 * @param	{String}	callback	URL or Callback JS function to call if yes answer
+	 * @param	{String}				Element to update after url completion
+	 * @param	{String}				URL of the update element
 	 *
 	 */
 	_getConfirmationButtons:  function(id, callback)
@@ -855,7 +862,7 @@ ION.append({
 	/**
 	 * Resizes one window based on its content
 	 *
-	 * @param	String		Windows ID, without the Mocha prefix (w)
+	 * @param	{String}	id		Windows ID, without the Mocha prefix (w)
 	 *
 	 */
 	windowResize: function(id, size, resize, centered )


### PR DESCRIPTION
… semicolons (browser compatibility), removed unnecessary semicolons, reduced duplicate variable definitions, reduced repeated identical sizzle selectors, removed silly (self referential) assignments, corrected some doc comments, simplified some conditions via ternary operation, simplified array instanciations, corrected some typos, made parseInt() calls failsave (added base)