### PR TITLE
Added refresh of list after extend-field delete

### DIFF
--- a/themes/admin/javascript/ionize/ionize_itemsmanager.js
+++ b/themes/admin/javascript/ionize/ionize_itemsmanager.js
@@ -103,7 +103,14 @@ ION.ItemManager = new Class({
 				{
 					id: id
 				},
-				{'confirm': self.options.confirmDelete, 'message': self.options.confirmDeleteMessage},
+				{
+					'confirm'	: self.options.confirmDelete, 
+					'message'	: self.options.confirmDeleteMessage
+					'onSuccess'	: function(){
+						// reload extend field list
+						$$('a[href=extend_field/index]')[0].click();
+					}
+				},
 				'JSON'
 			)
 		});


### PR DESCRIPTION
The list of extend fields so far was not refreshed upon deleting a field. Why refresh instead of remove the deleted item from DOM? -> Just removing the deleted element from the DOM would not remove the parent "type" container (Page / Article / etc. ) when containing no more items.