### PR TITLE
Set explicit SimpleXMLObject leaf casting

### DIFF
--- a/application/controllers/admin/modules.php
+++ b/application/controllers/admin/modules.php
@@ -270,7 +270,7 @@ class Modules extends MY_admin
 			// Create tables
 			foreach ($tables as $sql)
 			{
-				if ( ! $this->db->simple_query($sql))
+				if ( ! $this->db->simple_query((string) $sql))
 				{
 					$errors[] = $sql;
 				}
@@ -279,7 +279,7 @@ class Modules extends MY_admin
 			// Add content
 			foreach ($content as $sql)
 			{
-				$this->db->simple_query($sql);
+				$this->db->simple_query((string) $sql);
 			}
 		}
 

--- a/install/class/Installer.php
+++ b/install/class/Installer.php
@@ -908,7 +908,7 @@ class Installer
 			// In case of migration, this script will only create the missing tables
 			foreach ($tables as $table)
 			{
-				$this->db->query($table);
+				$this->db->query((string) $table);
 			}
 			
 			// Checks the write rights of the MySQL user
@@ -926,7 +926,7 @@ class Installer
 			// In case of migration (content already exists), the existing content will not be overwritten
 			foreach ($content as $sql)
 			{
-				$this->db->query($sql);
+				$this->db->query((string) $sql);
 			}
 			
 			// Users message
@@ -1487,7 +1487,7 @@ class Installer
 
 		foreach ($queries as $query)
 		{
-			$result = $this->db->query($query);
+			$result = $this->db->query((string) $query);
 
 			if ( ! $result)
 				log_message('error',$query);


### PR DESCRIPTION
Explicit string cast when creating databases to make Ionize work in HHVM environment.
Credits to Patrick Clara.