### PR TITLE
Added marking of previewed offline pages

### DIFF
--- a/application/helpers/navigation_helper.php
+++ b/application/helpers/navigation_helper.php
@@ -75,8 +75,13 @@ if( ! function_exists('get_tree_navigation'))
 				if ($key == 0 && ! is_null($first_class)) $class[] = $first_class;
 				if ($key == (count($items) - 1) && ! is_null($last_class)) $class[] = $last_class;
 				
-				$class = ( ! empty($class)) ? ' class="'.implode(' ', $class).'"' : '';
-				$li_class = ( ! empty($page['children'])) ? ' class="has-dropdown not-click'.implode(' ', $class).'"' : $class;
+				$additionalClass = $page['online'] === '0' ? ' offline' : '';
+				
+				$class = ( ! empty($class)) ? ' class="'.implode(' ', $class) .$additionalClass.'"' : '';
+				
+				$li_class = ( ! empty($page['children'])) 
+					? ' class="has-dropdown not-click'.implode(' ', $class).$additionalClass.'"' 
+					: $class;
 
 				$title = ($page['nav_title'] != '') ? $page['nav_title'] : $page['title'];
 				

--- a/themes/admin/styles/original/css/logged-as-editor.css
+++ b/themes/admin/styles/original/css/logged-as-editor.css
@@ -31,3 +31,9 @@ when the user is connected to the Admin panel as Editor.
 	text-decoration: none;
 	background: none;	
 }
+
+/* Mark offline pages, eg. in tree_navigation, as being only shown during preview of logged-in administrator */
+.offline {
+	border: 2px dotted rgba(255, 0, 0, 0.2);
+	background-color: rgba(255, 255, 0, 0.2);
+}


### PR DESCRIPTION
Pages that are offline, but shown as preview within tree-navigations, because the user is currently logged-in to the backend as administrator as well, are now visually marked (transparent light-yellow background and transparend red dotted border) as previewed elements, to make this (helpful, but otherwise easily confusing) behavior clear to the user.