### PR TITLE
Bugfix: Added missing refresh after delete extend field

### DIFF
--- a/application/controllers/admin/extend_field.php
+++ b/application/controllers/admin/extend_field.php
@@ -372,7 +372,19 @@ class Extend_field extends MY_admin
 				if ( ! $result)
 					$this->error(lang('ionize_message_extend_field_not_deleted'));
 				else
-					$this->success(lang('ionize_message_extend_field_deleted'));
+					$this->success(
+						lang('ionize_message_extend_field_deleted'),
+						array(
+							'callback'=> array(
+								'fn' => 'ION.contentUpdate',
+								'args' => array(
+									'element'	=> 'mainPanel',
+									'url'		=> 'extend_field/index',
+									'title'		=> lang('ionize_title_extend_fields')
+								)
+							)
+						)
+					);
 			}
 			catch(Exception $e)
 			{

--- a/themes/admin/views/extend/table_field.php
+++ b/themes/admin/views/extend/table_field.php
@@ -132,12 +132,11 @@
 		$('auto_increment_block').setStyle('display', 'none');
 		$('constraint_block').setStyle('display', 'none');
 	
-		if ($('type').value == 'VARCHAR' || $('type').value == 'INT')
+		var typeValue = $('type').value; 
+		if (typeValue == 'VARCHAR' || typeValue == 'INT')
 		{
 			$('constraint_block').setStyle('display', 'block');
-		}
-		
-		if ($('type').value == 'INT')
+		} else if (typeValue == 'INT')
 		{
 			$('unsigned_block').setStyle('display', 'block');
 			$('auto_increment_block').setStyle('display', 'block');

--- a/themes/admin/views/extend/table_field.php
+++ b/themes/admin/views/extend/table_field.php
@@ -136,10 +136,12 @@
 		if (typeValue == 'VARCHAR' || typeValue == 'INT')
 		{
 			$('constraint_block').setStyle('display', 'block');
-		} else if (typeValue == 'INT')
-		{
-			$('unsigned_block').setStyle('display', 'block');
-			$('auto_increment_block').setStyle('display', 'block');
+			
+			if (typeValue == 'INT') 
+			{
+				$('unsigned_block').setStyle('display', 'block');
+				$('auto_increment_block').setStyle('display', 'block');
+			}
 		}
 	}
 	


### PR DESCRIPTION
After deleting extend fields, the fields list is now reloaded so that removed fields are not displayed anymore.