### PR TITLE
Bugfix: content element > inline preview was displaced

### DIFF
--- a/themes/admin/views/element/content_list.php
+++ b/themes/admin/views/element/content_list.php
@@ -350,6 +350,7 @@ $width = (100 / $nbLang);
 	{
 		ION.initListToggler(el, $('def_' + el.getProperty('data-id')));
 	});
+	$('def_<?php echo $id_definition; ?>').getParent('div').style.width="100%";
 	<?php endif ;?>
 
 	// Edit on each element


### PR DESCRIPTION
the expanded preview of content element values was (tested in firefox) displaced and cut-off at the right, only a minimum part was visible in the preview at all.