### PR TITLE
Added "usage" tab to element definition item

### DIFF
--- a/application/controllers/admin/element_definition.php
+++ b/application/controllers/admin/element_definition.php
@@ -36,6 +36,12 @@ class Element_definition extends MY_Admin {
 
 	/** @var  Extend_field_model */
 	public $extend_field_model;
+	
+	/** @var  Page_model */
+	public $page_model;
+
+	/** @var  Article_model */
+	public $article_model;
 
 	// ------------------------------------------------------------------------
 	
@@ -49,7 +55,9 @@ class Element_definition extends MY_Admin {
             array(
                 'element_model',
                 'element_definition_model',
-                'extend_field_model'
+                'extend_field_model',
+                'page_model',
+		'article_model'
             ), '', TRUE);
 	}
 
@@ -149,6 +157,27 @@ class Element_definition extends MY_Admin {
 				),
 				Settings::get_lang('default')
 			);
+			
+			// Element usages on pages, articles
+			$query = $this->db
+				->where('id_element_definition = ' . $element['id_element_definition'])
+				->from('element')
+				->get();
+
+			$usages= $query->result_array();
+			foreach($usages as $index => $usageElement) {
+				if( $usageElement['parent'] === 'page' ) {
+					// get page: parent page of element
+					$usages[$index]['page']	= $this->page_model->get_by_id($usageElement['id_parent']);
+					$usages[$index]['article']	= null;
+				} else {
+					// get page: parent page of article which is parent of element
+					$usages[$index]['article'] = $this->article_model->get_by_id($usageElement['id_parent']);
+					$usages[$index]['page']	= $this->page_model->get_by_id($usages[$index]['article']['id_page']);
+				}
+			}
+
+			$element['usages'] = $usages;
 		}
 
 		$this->template['elements'] = $elements;

--- a/application/language/en/admin_lang.php
+++ b/application/language/en/admin_lang.php
@@ -393,6 +393,7 @@ $lang['ionize_button_yes'] = 'Yes';
 $lang['button_delete_installer_done_admin'] = 'Done! Go to Admin panel';
 $lang['button_delete_installer_done_site'] = 'Done! Go to website';
 $lang['ionize_confirm_element_delete'] = 'Do you want to definitely delete this element?';
+$lang['ionize_confirm_element_delete_usage'] = 'Do you want to definitely delete this element usage?';
 $lang['ionize_message_delete_installer'] = 'IMPORTANT: <br/>For security reasons, please delete the <b>"/install"</b> folder. Ionize will not be available until this folder is deleted.';
 $lang['ionize_message_element_not_found'] = 'This element wasn\'t found!';
 $lang['ionize_message_form_validation_error'] = 'Some data are missing or incorrect';

--- a/application/language/en/admin_lang.php
+++ b/application/language/en/admin_lang.php
@@ -164,6 +164,7 @@ $lang['ionize_title_existing_menu'] = 'Existing menu';
 |--------------------------------------------------------------------------
 */
 $lang['ionize_button_save_element'] = 'Save this Element';
+$lang['ionize_button_usage'] = 'Usages';
 $lang['ionize_label_add_content_element'] = 'Add Element';
 $lang['ionize_label_back_to_element_list'] = 'Back to Elements';
 $lang['ionize_label_content_element'] = 'Content Element';

--- a/themes/admin/javascript/ionize/ionize_content.js
+++ b/themes/admin/javascript/ionize/ionize_content.js
@@ -957,7 +957,7 @@ ION.append({
 	{
 		// tabSwapper elements
 		var tabSwapper = $('desktop').retrieve('tabSwapper');
-		var tabs = 		tabSwapper.tabs;
+		var tabs = 		tabSwapper ? tabSwapper.tabs : [];
 		
 		// DOM elements
 		var tabsContainer = $(tabSwapper.options.tabsContainer);
@@ -984,7 +984,11 @@ ION.append({
 					var found = false;
 					index = tabs.length;
 					
-					tabs.each(function(tab) { if (tab.hasClass('tab' + id)) { found = tab; } });
+					tabs.each(function(tab) { 
+						if (tab.hasClass('tab' + id)) { 
+							found = tab; 
+						}
+					});
 
 					// Not found ? Build it !
 					if (found == false)
@@ -1059,7 +1063,7 @@ ION.append({
 	deleteTab: function(id)
 	{
 		var tabSwapper = $('desktop').retrieve('tabSwapper');
-		var tabs = tabSwapper.tabs;
+		var tabs = tabSwapper ? tabSwapper.tabs : [];
 
 		tabs.each(function(tab, idx)
 		{

--- a/themes/admin/styles/original/css/content.css
+++ b/themes/admin/styles/original/css/content.css
@@ -225,7 +225,8 @@ li.offline { opacity:0.7; }
 .icon.offline, 		.button i.icon-offline		{background-position: -80px -32px;}
 .icon.link,		    .button i.icon-link 		{background-position: -208px -32px;}
 .icon.unlink,		.button i.icon-unlink 		{background-position: -128px -32px;}
-.icon.delete,		.button i.icon-delete 		{background-position: -160px -64px;}
+.icon.delete,		.button i.icon-delete,
+.icon.delete-usage, .button i.icon-delete-usage		{background-position: -160px -64px;}
 .icon.article,		.button i.icon-article		{background-position: -144px -16px;}
 .icon.article.add,	.button i.icon-article.add	{background-position: -208px -16px;}
 .icon.page.add,	    .button i.icon-page.add	    {background-position: -224px -16px;}

--- a/themes/admin/views/element/definition.php
+++ b/themes/admin/views/element/definition.php
@@ -65,7 +65,7 @@ $id = $id_element_definition;
 							<li <?php if($language['def'] == '1') :?> class="dl"<?php endif ;?>><a><?php echo ucfirst($language['name']) ;?></a></li>
 						<?php endforeach ;?>
 
-						<li class="right" id="usageTab"><a><?php echo lang('ionize_button_usage'); ?></a></li>
+						<li class="right" id="usageTab"><a><?php echo count($usages) . ' ' . lang('ionize_button_usage'); ?></a></li>
 					</ul>
 					<div class="clear"></div>
 
@@ -85,6 +85,42 @@ $id = $id_element_definition;
 
 					<?php endforeach ;?>
 
+					<div class="tabcontent">
+						<table class="list">
+							<thead>
+							<tr>
+								<th><?php echo lang('ionize_title_pages'); ?></th>
+								<th><?php echo lang('ionize_title_articles'); ?></th>
+								<th style="width:70px;" class="right"></th>
+							</tr>
+							</thead>
+
+							<tbody>
+							<?php foreach($usages as $elementUsage) { ?>
+								<tr>
+									<td class="pl10">
+										<a title="<?php echo $elementUsage['page']['id_page'] ?>: <?php echo $elementUsage['page']['name'] ?>" onclick="$$('a.page<?php echo $elementUsage['page']['id_page'] ?>').getLast().fireEvent('click')" class="page-breadcrumb">
+											<?php echo $elementUsage['page']['name'] ?>
+										</a>
+									</td>
+									<td class="pl10">
+										<?php if( $elementUsage['article'] === null ) { ?>
+											-
+										<?php } else { ?>
+											<a title="<?php echo $elementUsage['page']['id_page'] ?>.<?php echo $elementUsage['article']['id_article'] ?>: <?php echo $elementUsage['article']['name'] ?>" onclick="$$('a.article<?php echo $elementUsage['page']['id_page'] ?>x<?php echo $elementUsage['article']['id_article'] ?>').getLast().fireEvent('click')" class="page-breadcrumb">
+												<?php echo $elementUsage['article']['name'] ?>
+											</a>
+										<?php } ?>
+									</td>
+									<td class="pr10">
+										<a data-id="<?php echo $elementUsage['id_element'] ?>" class="delete-usage icon right"></a>
+									</td>
+								</tr>
+							<?php } ?>
+							</tbody>
+						</table>
+					</div>
+					
 				</div>
 
 				<hr />
@@ -151,7 +187,7 @@ $id = $id_element_definition;
 
 </li>
 <script type="text/javascript">
-    new TabSwapper({
+    	new TabSwapper({
 		tabsContainer: 'elementDefinitonTab<?php echo $id ;?>',
 		sectionsContainer: 'elementDefinitionTabContent<?php echo $id ;?>',
 		selectedClass: 'selected',
@@ -160,4 +196,22 @@ $id = $id_element_definition;
 		clickers: 'li a',
 		sections: 'div.tabcontent'
 	});
+	
+	$$('.delete-usage').each(function(el){
+		el.addEvent('click', function() {
+			ION.initRequestEvent(
+				el,
+				admin_url + 'element/delete/' + el.get('data-id'),
+				{},
+				{
+					'confirm': true,
+					'message': Lang.get('ionize_confirm_element_delete_usage'),
+					'onSuccess': function()
+					{
+						$$('a[href="element_definition/index"]')[0].click();
+					}
+				}
+			);
+		});
+	});	
 </script>

--- a/themes/admin/views/element/definition.php
+++ b/themes/admin/views/element/definition.php
@@ -6,20 +6,20 @@ $id = $id_element_definition;
 
 <li class="sortme nohover element_definition" id="element_definition_<?php echo $id ;?>" data-id="<?php echo $id ;?>">
 
-
-    <div class="h20">
+	<div class="h20">
 
 		<?php if ( Authority::can('delete', 'admin/element')) :?>
-
-   			<a class="icon delete right" data-id="<?php echo $id ;?>"></a>
-
+			<a class="icon delete right" data-id="<?php echo $id ;?>"></a>
 		<?php endif;?>
 
-        <span class="icon left drag mr10"></span>
+		<span class="icon left drag mr10"></span>
+		<span class="toggler element-list" style="float:left">&nbsp;</span>
 
-        <?php if ($name == '') :?>
-			<input id="elementName<?php echo $id ;?>" type="text" class="inputtext w120 left" />
-			<button id="elementDefinitionSave<?php echo $id ;?>" type="button" class="light-button left ml10" value="Save"><?php echo lang('ionize_label_element_set_name') ;?></button>
+		<?php if ($name == '') :?>
+		<input id="elementName<?php echo $id ;?>" type="text" class="inputtext w120 left" />
+			<button id="elementDefinitionSave<?php echo $id ;?>" type="button" class="light-button left ml10" value="Save">
+				<?php echo lang('ionize_label_element_set_name') ;?>
+			</button>
 
 			<script type="text/javascript">
 				var func_save = function()
@@ -46,108 +46,108 @@ $id = $id_element_definition;
 				$('element_definition_<?php echo $id ;?>').addClass('stripped');
 			</script>
 
-        <?php else :?>
-
-        	<a class="edit name left" data-id="<?php echo $id ;?>"><?php echo $name ;?></a>
-
+		<?php else :?>
+			<a class="edit name left" data-id="<?php echo $id ;?>"><?php echo $name ;?></a>
 		<?php endif ;?>
 
-
 	</div>
+	<div class="element element-list">
 
-    <?php if ($name != '') :?>
+		<?php if ($name != '') :?>
 
-		<div class="clear mt10 mr20 ml40 ">
+			<div class="clear mt10 mr20 ml40 ">
 
-			<!-- Tabs -->
-			<div id="elementDefinitonTab<?php echo $id ;?>" class="mainTabs">
+				<!-- Tabs -->
+				<div id="elementDefinitonTab<?php echo $id ;?>" class="mainTabs">
 
-				<ul class="tab-menu">
-					<?php foreach(Settings::get_languages() as $language) :?>
-						<li <?php if($language['def'] == '1') :?> class="dl"<?php endif ;?>><a><?php echo ucfirst($language['name']) ;?></a></li>
+					<ul class="tab-menu">
+						<?php foreach(Settings::get_languages() as $language) :?>
+							<li <?php if($language['def'] == '1') :?> class="dl"<?php endif ;?>><a><?php echo ucfirst($language['name']) ;?></a></li>
+						<?php endforeach ;?>
+
+						<li class="right" id="usageTab"><a><?php echo lang('ionize_button_usage'); ?></a></li>
+					</ul>
+					<div class="clear"></div>
+
+				</div>
+
+				<div id="elementDefinitionTabContent<?php echo $id ;?>" class="ml20 mr20 mb10">
+
+					<!-- Text block -->
+					<?php foreach(Settings::get_languages() as $language) :
+						$lang = $language['lang'];
+						$aTitle = lang('ionize_label_change').' '.lang('ionize_label_title');
+					?>
+
+						<div class="tabcontent">
+							<a class="edit title left" data-id="<?php echo $id ;?>.<?php echo $lang ;?>" title="<?php echo $aTitle ;?>"><?php echo $languages[$lang]['title'] ;?></a>
+						</div>
+
 					<?php endforeach ;?>
-				</ul>
-				<div class="clear"></div>
 
-			</div>
+				</div>
 
-			<div id="elementDefinitionTabContent<?php echo $id ;?>" class="ml20 mr20 mb10">
+				<hr />
 
-				<!-- Text block -->
-				<?php foreach(Settings::get_languages() as $language) :
-					$lang = $language['lang'];
-					$aTitle = lang('ionize_label_change').' '.lang('ionize_label_title');
+				<!-- Fields -->
+				<div style="overflow:hidden;clear:both;">
+
+					<div class="pt5" id="def_<?php echo $id ;?>">
+
+						<!-- Add Field button -->
+						<?php if ($id != 0 && Authority::can('edit', 'admin/element')) :?>
+							<a class="light button plus mb5 ml5 add_field" data-id="<?php echo $id ;?>">
+								<i class="icon-plus"></i>
+								Add field
+							</a>
+						<?php endif ;?>
+
+						<ul class="fields" id="fields<?php echo $id ;?>" data-id="<?php echo $id ;?>">
+
+							<?php foreach($fields as $field) :?>
+								<li class="sortme element_field" data-id="<?php echo $field['id_extend_field'] ;?>" id="element_field<?php echo $field['id_extend_field'] ;?>">
+									<span class="icon left drag"></span>
+
+									<?php if ( Authority::can('edit', 'admin/element')) :?>
+										<a class="icon delete right" data-id="<?php echo $field['id_extend_field'] ;?>"></a>
+									<?php endif ;?>
+
+									<span class="lite right mr10" data-id="<?php echo $field['id_extend_field'] ;?>">
+										<?php echo $field['type_name'] ;?>
+										<?php if($field['translated'] == '1') :?>
+											/ <?php echo lang('ionize_label_multilingual') ;?>
+										<?php endif ;?>
+									</span>
+
+									<a class="left ml10 edit_field" data-id="<?php echo $field['id_extend_field'] ;?>"><?php echo $field['name'] ;?></a>
+								</li>
+							<?php endforeach ;;?>
+						</ul>
+					</div>
+				</div>
+
+
+				<!-- Order items by... button -->
+				<?php
+
+				/*
+				 * @TODO : 	Define the ordering when adding one element
+				 * 			Planned for 1.0
+				 *
+				<hr/>
+
+				<label for=""><? echo lang('ionize_next_element_will_be') ?></label>
+				<select class="inputtext" name="order_by">
+					<option value="-1" label="Descroissant"><?php echo lang('ionize_label_first') ;?></option>
+					<option value="1" label="Croissant"><?php echo lang('ionize_label_last') ;?></option>
+				</select>
+				*/
 				?>
 
-					<div class="tabcontent">
-						<a class="edit title left" data-id="<?php echo $id ;?>.<?php echo $lang ;?>" title="<?php echo $aTitle ;?>"><?php echo $languages[$lang]['title'] ;?></a>
-					</div>
-
-				<?php endforeach ;?>
-
 			</div>
 
-			<hr />
-
-			<!-- Fields -->
-			<div style="overflow:hidden;clear:both;">
-
-				<div class="pt5" id="def_<?php echo $id ;?>">
-
-					<!-- Add Field button -->
-					<?php if ($id != 0 && Authority::can('edit', 'admin/element')) :?>
-						<a class="light button plus mb5 ml5 add_field" data-id="<?php echo $id ;?>">
-							<i class="icon-plus"></i>
-							Add field
-						</a>
-					<?php endif ;?>
-
-					<ul class="fields" id="fields<?php echo $id ;?>" data-id="<?php echo $id ;?>">
-
-						<?php foreach($fields as $field) :?>
-							<li class="sortme element_field" data-id="<?php echo $field['id_extend_field'] ;?>" id="element_field<?php echo $field['id_extend_field'] ;?>">
-								<span class="icon left drag"></span>
-
-								<?php if ( Authority::can('edit', 'admin/element')) :?>
-            						<a class="icon delete right" data-id="<?php echo $field['id_extend_field'] ;?>"></a>
-								<?php endif ;?>
-
-								<span class="lite right mr10" data-id="<?php echo $field['id_extend_field'] ;?>">
-									<?php echo $field['type_name'] ;?>
-									<?php if($field['translated'] == '1') :?>
-										/ <?php echo lang('ionize_label_multilingual') ;?>
-									<?php endif ;?>
-								</span>
-
-								<a class="left ml10 edit_field" data-id="<?php echo $field['id_extend_field'] ;?>"><?php echo $field['name'] ;?></a>
-							</li>
-						<?php endforeach ;;?>
-					</ul>
-				</div>
-			</div>
-
-
-            <!-- Order items by... button -->
-			<?php
-
-			/*
-			 * @TODO : 	Define the ordering when adding one element
-			 * 			Planned for 1.0
-			 *
-			<hr/>
-
-			<label for=""><? echo lang('ionize_next_element_will_be') ?></label>
-			<select class="inputtext" name="order_by">
-				<option value="-1" label="Descroissant"><?php echo lang('ionize_label_first') ;?></option>
-				<option value="1" label="Croissant"><?php echo lang('ionize_label_last') ;?></option>
-			</select>
-			*/
-			?>
-
-		</div>
-
-    <?php endif ;?>
-
+		<?php endif ;?>
+	</div>
 
 </li>
 <script type="text/javascript">

--- a/themes/admin/views/element/definition/list.php
+++ b/themes/admin/views/element/definition/list.php
@@ -8,9 +8,16 @@
 
 <script type="text/javascript">
 
+	ION.initAccordion(
+		'.toggler.element-list',
+		'.element.element-list',
+		false,
+		'elementListAccordion'
+	);
+
 	//  Content Element itemManager
-    var elementManager = new ION.ItemManager({container: 'elementContainer', 'element':'element_definition'});
-    elementManager.makeSortable();
+	var elementManager = new ION.ItemManager({container: 'elementContainer', 'element':'element_definition'});
+	elementManager.makeSortable();
 
 	<?php if ( Authority::can('edit', 'admin/element')) :?>
 


### PR DESCRIPTION
Using this tab, one can find usages of elements on pages and articles quickly, and delete select ones (similar to the options in the articles list)