### PR TITLE
ionize/ionize.git#221

### DIFF
--- a/system/database/drivers/mysqli/mysqli_driver.php
+++ b/system/database/drivers/mysqli/mysqli_driver.php
@@ -300,10 +300,6 @@ class CI_DB_mysqli_driver extends CI_DB {
 		{
 			$str = mysqli_real_escape_string($this->conn_id, $str);
 		}
-		elseif (function_exists('mysql_escape_string'))
-		{
-			$str = mysql_escape_string($str);
-		}
 		else
 		{
 			$str = addslashes($str);


### PR DESCRIPTION
mysql_escape_string function is deprecated and mysqli_escape_string is an alias for mysqli_real_escape_string therefore the elseif not needed.

Signed-off-by: Liszkai Ádám <contact@liszkaiadam.hu>