### PR TITLE
Performance: simplified boolean expressions

### DIFF
--- a/application/controllers/admin/role.php
+++ b/application/controllers/admin/role.php
@@ -255,7 +255,7 @@ class Role extends MY_Admin
 	 */
 	public function _filter_roles($row)
 	{
-		return ($row['role_level'] <= $this->current_role['role_level']) ? TRUE : FALSE;
+		return ($row['role_level'] <= $this->current_role['role_level']);
 	}
 
 

--- a/application/controllers/admin/setting.php
+++ b/application/controllers/admin/setting.php
@@ -1375,7 +1375,7 @@ class Setting extends MY_admin
 
 		/* Lang settings to Settings
 		 */
-		$callback = create_function('$v', 'return ($v["lang"]!="") ? true : false;');
+		$callback = create_function('$v', 'return ($v["lang"]!="");');
 		$lang_settings = array_filter($settings, $callback );
 
 		Settings::set_lang_settings($lang_settings, 'name', 'content');

--- a/application/controllers/admin/user.php
+++ b/application/controllers/admin/user.php
@@ -420,7 +420,7 @@ class User extends My_Admin
 	 */
 	public function _filter_roles($row)
 	{
-		return ($row['role_level'] <= $this->current_role['role_level']) ? true : false;
+		return ($row['role_level'] <= $this->current_role['role_level']);
 	}
 
 

--- a/application/controllers/picture.php
+++ b/application/controllers/picture.php
@@ -64,7 +64,7 @@ class Picture extends Base_Controller
 
 			$thumb_file_path = $this->medias->get_thumb_file_path($picture, $options);
 
-			$refresh = ! empty($options['refresh']) ? TRUE : FALSE;
+			$refresh = ! empty($options['refresh']);
 
 			// If no thumb, try to create it
 			if ( ! file_exists($thumb_file_path) OR $refresh === TRUE)

--- a/application/helpers/MY_date_helper.php
+++ b/application/helpers/MY_date_helper.php
@@ -24,7 +24,7 @@ if ( ! function_exists('isDate'))
 {
 	function isDate($mysqlDatetime)
 	{
-		return ($mysqlDatetime != '0000-00-00 00:00:00' && $mysqlDatetime != '') ? true : false;
+		return ($mysqlDatetime != '0000-00-00 00:00:00' && $mysqlDatetime != '');
 	}
 }
 

--- a/application/helpers/MY_form_helper.php
+++ b/application/helpers/MY_form_helper.php
@@ -161,7 +161,7 @@ if ( ! function_exists('form_build_field'))
 				{
 					$id = 'c_'.uniqid();
 					$extra2 = $extra . ' id="'.$id.'"';
-					$checked = ($field_value == $value) ? TRUE : FALSE;
+					$checked = ($field_value == $value);
 					if ($print_label === TRUE)
 						$str .= form_label($label, $id);
 					$str .= form_checkbox($field_name, $value, $checked, $extra2);
@@ -185,7 +185,7 @@ if ( ! function_exists('form_build_field'))
 				{
 					$id = 'r_'.uniqid();
 					$extra2 = $extra . ' id="'.$id.'"';
-					$checked = ($field_value == $value) ? TRUE : FALSE;
+					$checked = ($field_value == $value);
 					if ($print_label === TRUE)
 						$str .= form_label($label, $id);
 					$str .= form_radio($field_name, $value, $checked, $extra2);

--- a/application/libraries/Filemanager.php
+++ b/application/libraries/Filemanager.php
@@ -1428,7 +1428,7 @@ class FileManager
 
 		$resize = (bool) ! empty($headers['X-Resize']) ? $headers['X-Resize'] : FALSE;
 		$resume_flag = ! empty($headers['X-File-Resume']) ? FILE_APPEND : 0;
-		$replace = (! empty($headers['X-Replace']) && $headers['X-Replace'] == 1 ) ? TRUE : FALSE;
+		$replace = (! empty($headers['X-Replace']) && $headers['X-Replace'] == 1 );
 
 		// Prepare the response
 		$response = array(

--- a/application/libraries/MY_Image_lib.php
+++ b/application/libraries/MY_Image_lib.php
@@ -70,7 +70,7 @@ class MY_Image_lib extends CI_Image_lib {
 			if ($this->gd_version() !== FALSE)
 			{
 				$gd_version = str_replace('0', '', $this->gd_version());
-				$v2_override = ($gd_version == 2) ? TRUE : FALSE;
+				$v2_override = ($gd_version == 2);
 			}
 		}
 		else

--- a/application/libraries/Tagmanager/Archive.php
+++ b/application/libraries/Tagmanager/Archive.php
@@ -119,7 +119,7 @@ class TagManager_Archive extends TagManager
 				$row['active_class'] = ($year == $_archive_string) ? $active_class : '';
 			}
 
-			$row['is_active'] = ! empty($row['active_class']) ? TRUE : FALSE;
+			$row['is_active'] = ! empty($row['active_class']);
 		}
 
 		return $archives;

--- a/application/libraries/Tagmanager/Article.php
+++ b/application/libraries/Tagmanager/Article.php
@@ -83,7 +83,7 @@ class TagManager_Article extends TagManager
 		}
 
 		// Set by Page::get_current_page()
-		$is_current_page = isset($page['__current__']) ? TRUE : FALSE;
+		$is_current_page = isset($page['__current__']);
 
 		// Pagination
 		$tag_pagination = $tag->getAttribute('pagination');
@@ -232,7 +232,7 @@ class TagManager_Article extends TagManager
 		if (empty($page)) $page = self::registry('page');
 
 		// Set by Page::get_current_page()
-		$is_current_page = isset($page['__current__']) ? TRUE : FALSE;
+		$is_current_page = isset($page['__current__']);
 
 		$special_uri_array = self::get_special_uri_array();
 

--- a/application/libraries/Tagmanager/Category.php
+++ b/application/libraries/Tagmanager/Category.php
@@ -116,7 +116,7 @@ class TagManager_Category extends TagManager
 
 				// Active category ?
 				$categories[$key]['active_class'] = ($category['name'] == $asked_category_name) ? $active_class : '';
-				$categories[$key]['is_active'] = ! empty($categories[$key]['active_class']) ? TRUE : FALSE;
+				$categories[$key]['is_active'] = ! empty($categories[$key]['active_class']);
 			}
 
 			self::$categories[$lsk] = array_values($categories);

--- a/application/libraries/Tagmanager/Navigation.php
+++ b/application/libraries/Tagmanager/Navigation.php
@@ -118,7 +118,7 @@ class TagManager_Navigation extends TagManager
 			$page['title'] = $page['nav_title'] !='' ? $page['nav_title'] : $page['title'];
 			// Add the active_class key
 			$page['active_class'] = in_array($page['id_page'], $active_pages) ? $active_class : '';
-			$page['is_active'] = in_array($page['id_page'], $active_pages) ? TRUE : FALSE;
+			$page['is_active'] = in_array($page['id_page'], $active_pages);
 			$page['id_navigation'] = $page['id_page'];
 		}
 

--- a/application/libraries/Tagmanager/Page.php
+++ b/application/libraries/Tagmanager/Page.php
@@ -654,7 +654,7 @@ class TagManager_Page extends TagManager
 		// Get the asked parent page : From current page or from page ID
 		if (!is_null($parent))
 		{
-			$all_parents = ( $tag->getAttribute('all-parents') == TRUE) ? TRUE : FALSE;
+			$all_parents = ( $tag->getAttribute('all-parents') == TRUE);
 
 			// Path IDs
 			if ($all_parents)

--- a/application/libraries/Tagmanager/Tag.php
+++ b/application/libraries/Tagmanager/Tag.php
@@ -189,7 +189,7 @@ class TagManager_Tag extends TagManager
 
 				// Active tag ?
 				$tags[$key]['active_class'] = ($t['tag_name'] == $asked_tag_name) ? $active_class : '';
-				$tags[$key]['is_active'] = 	($t['tag_name'] == $asked_tag_name) ? TRUE : FALSE;
+				$tags[$key]['is_active'] = 	($t['tag_name'] == $asked_tag_name);
 			}
 
 			self::$tags[$lsk] = array_values($tags);

--- a/application/models/url_model.php
+++ b/application/models/url_model.php
@@ -306,7 +306,7 @@ class Url_model extends Base_model
 	{
 		self::$ci->load->model('page_model', '', TRUE);
 
-		$short_url_mode = config_item('url_mode') == 'short' ? TRUE : FALSE;
+		$short_url_mode = config_item('url_mode') == 'short';
 
 		$current = array();
 


### PR DESCRIPTION
Explanation: all conditions result in either true or false, never anything else. using a ternary operator to convert that true or false into (the same) true or false is simply unnessary.