### PR TITLE
Bugfix: Tagmanager - parse URL of internal link of ext. field failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Ionize CMS - Changelog
 ======================
 
 * Version 1.0.8 - Not released yet
+ * Bugfix: Tagmanager - parse URL of internal link item in extend field failed (was returning empty string) 
  * Added: autocorrection on blur to url field of page and article
  * Added: Extend field key is suggested from label
  * Improved: FTL parser performance

--- a/application/libraries/Tagmanager.php
+++ b/application/libraries/Tagmanager.php
@@ -1865,6 +1865,19 @@ class TagManager
 			$parent = $tag->getParent();
 			$value = $parent->getValue('absolute_url');
 		}
+		
+		// 3. Check for internal page links: get URL of first linked page
+		if( is_null($value))
+		{
+			$pages = self::tag_extend_field_value($tag);
+			if(substr($pages, 0, 5) === 'page:') {
+				$pages = explode(',', $pages);
+				$idPage	= substr($pages[0], strpos($pages[0], ':')+1); // get ID of first page
+				$page = self::$ci->page_model->get_by_id($idPage);
+
+				$value = base_url() . ($page['home'] === '1' ? '' : $page['path']);
+			}
+		}
 
 		if ( ! is_null($type) && ! is_null($value))
 		{


### PR DESCRIPTION
when parsing an extend field containing an internal links item, &lt;ion:extend:myextfield&gt;&lt;ion:url /&gt;&lt;/ion:extend:myextfield&gt; was returning an empty string instead of the page url.