### PR TITLE
Added page tag: ion:page:if_in_rootline

### DIFF
--- a/application/libraries/Tagmanager/Page.php
+++ b/application/libraries/Tagmanager/Page.php
@@ -725,7 +725,7 @@ class TagManager_Page extends TagManager
 	 * @usage	In views :
 	 * 			<ion:page:if_in_rootline id="3">
 	 * 				This will be displayed if given id (3) is an id_page of an ancestor of the page
-	 * 			</ion:my_tag:is_active>
+	 * 			</ion:page:if_in_rootline>
 	 */
 	public static function tag_if_in_rootline(FTL_Binding $tag)
 	{

--- a/application/libraries/Tagmanager/Page.php
+++ b/application/libraries/Tagmanager/Page.php
@@ -37,13 +37,15 @@ class TagManager_Page extends TagManager
 
 	public static $tag_definitions = array
 	(
-		'pages'		=> 	'tag_pages',
-		'page'		=> 	'tag_page',
-		'page:view' => 	'tag_page_view',
-		'page:next' =>	'tag_next_page',
-		'page:prev' =>	'tag_prev_page',
-		'breadcrumb'=>	'tag_breadcrumb',
-		'id_parent' => 	'tag_simple_value'
+		'pages'		=> 'tag_pages',
+		'page'		=> 'tag_page',
+		'page:view'	=> 'tag_page_view',
+		'page:next'	=> 'tag_next_page',
+		'page:prev'	=> 'tag_prev_page',
+		'breadcrumb'	=> 'tag_breadcrumb',
+		'id_parent'	=> 'tag_simple_value',
+		
+		'if_in_rootline'=> 'tag_if_in_rootline'
 	);
 
 
@@ -707,6 +709,35 @@ class TagManager_Page extends TagManager
 			self::set_cache($tag, $str);
 		}
 		return $str;
+	}
+	
+
+	// ------------------------------------------------------------------------
+
+
+	/**
+	 * Expands the tag content if the page is a descendant of the given ancestor page
+	 *
+	 * @param 	FTL_Binding $tag
+	 *
+	 * @return 	string
+	 *
+	 * @usage	In views :
+	 * 			<ion:page:if_in_rootline id="3">
+	 * 				This will be displayed if given id (3) is an id_page of an ancestor of the page
+	 * 			</ion:my_tag:is_active>
+	 */
+	public static function tag_if_in_rootline(FTL_Binding $tag)
+	{
+		$page = self::$context->registry('page');
+		$id_page = (int) $page['id'];
+
+		$id_page_ancestor = (int) $tag->getAttribute('id');
+
+		if (self::$ci->page_model->is_id_in_rootline($id_page, $id_page_ancestor))
+			return $tag->expand();
+
+		return '';
 	}
 
 

--- a/application/models/page_model.php
+++ b/application/models/page_model.php
@@ -501,6 +501,25 @@ class Page_model extends Base_model
 
 		return $ids;
 	}
+	
+	
+	// ------------------------------------------------------------------------
+
+
+	/**
+	 * @param	int	$id_page
+	 * @param	int	$id_page_ancestor
+	 * @return	bool	Is given page a descendant of given ancestor?
+	 */
+	public function is_id_in_rootline($id_page, $id_page_ancestor)
+	{
+		$ids_in_rootline = $this->get_children_ids($id_page_ancestor);
+
+		return in_array($id_page, $ids_in_rootline);
+	}
+
+
+	// ------------------------------------------------------------------------
 
 
 	/**


### PR DESCRIPTION
Usage Example:

&lt;ion:page:if_in_rootline id="3"&gt;
	This will be displayed if given id (3) is an id_page of an ancestor of the page
&lt;/ion:my_tag:is_active&gt;