### PR TITLE
Added page tag: ion:page:if_is_descendant_of

### DIFF
--- a/application/libraries/Tagmanager/Page.php
+++ b/application/libraries/Tagmanager/Page.php
@@ -43,7 +43,9 @@ class TagManager_Page extends TagManager
 		'page:next' =>	'tag_next_page',
 		'page:prev' =>	'tag_prev_page',
 		'breadcrumb'=>	'tag_breadcrumb',
-		'id_parent' => 	'tag_simple_value'
+		'id_parent' => 	'tag_simple_value',
+		
+		'if_is_descendant_of'	=> 'tag_if_is_descendant_of'
 	);
 
 
@@ -1001,6 +1003,56 @@ class TagManager_Page extends TagManager
 		$return = self::prefix_suffix_process($return, $tag->getAttribute('prefix'));
 
 		return self::wrap($tag, $return);
+	}
+
+
+	// ------------------------------------------------------------------------
+
+
+	/**
+	 * Expands the tag content if the page is a descendant of the given ancestor page
+	 *
+	 * @param 	FTL_Binding $tag
+	 *
+	 * @return 	string
+	 *
+	 * @usage	In views :
+	 *
+	 * 			<ion:page:tag_if_is_descendant_of id="3">
+	 * 				This will be displayed if given id (3) is an id_page of any ancestor of the page, but not the id of the page
+	 * 			</ion:page:tag_if_is_descendant_of>
+	 *
+	 * 			<ion:page:tag_if_is_descendant_of id="3" include_page="true">
+	 * 				This will be displayed if given id (3) is an id_page of any ancestor of the page, or the id of the page
+	 * 			</ion:page:tag_if_is_descendant_of>
+	 *
+	 * 			<ion:page:tag_if_is_descendant_of id="3" include_page="true" max_levels="1">
+	 * 				This will be displayed if given id (3) is an id_page of a 1st level ancestor (parent actually) of the page, or the id of the page
+	 * 			</ion:page:tag_if_is_descendant_of>
+	 *
+	 * 			<ion:page:tag_if_is_descendant_of ids="3,18">
+	 * 				This will be displayed if one of the given ids (3,18) is an id_page of an ancestor of the page, but not the id of the page
+	 * 			</ion:page:tag_if_is_descendant_of>
+	 */
+	public static function tag_if_is_descendant_of(FTL_Binding $tag)
+	{
+		$page = self::$context->registry('page');
+		$id_page = (int) $page['id'];
+
+		$ancestor_id = (int) $tag->getAttribute('id');
+		if( $ancestor_id === 0 ) {
+			$ancestor_ids = explode(',', $tag->getAttribute('ids'));
+		} else {
+			$ancestor_ids = array($ancestor_id);
+		}
+
+		$include_page_id = (bool) $tag->getAttribute('include_page_id');
+		$max_levels = (int) $tag->getAttribute('max_levels');
+
+		if (self::$ci->page_model->is_ancestor_of($ancestor_ids, $id_page, $include_page_id, $max_levels))
+			return $tag->expand();
+
+		return '';
 	}
 
 

--- a/application/libraries/Tagmanager/Page.php
+++ b/application/libraries/Tagmanager/Page.php
@@ -1018,21 +1018,21 @@ class TagManager_Page extends TagManager
 	 *
 	 * @usage	In views :
 	 *
-	 * 			<ion:page:tag_if_is_descendant_of id="3">
+	 * 			<ion:page:if_is_descendant_of id="3">
 	 * 				This will be displayed if given id (3) is an id_page of any ancestor of the page, but not the id of the page
-	 * 			</ion:page:tag_if_is_descendant_of>
+	 * 			</ion:page:if_is_descendant_of>
 	 *
-	 * 			<ion:page:tag_if_is_descendant_of id="3" include_page="true">
+	 * 			<ion:page:if_is_descendant_of id="3" include_page="true">
 	 * 				This will be displayed if given id (3) is an id_page of any ancestor of the page, or the id of the page
-	 * 			</ion:page:tag_if_is_descendant_of>
+	 * 			</ion:page:if_is_descendant_of>
 	 *
-	 * 			<ion:page:tag_if_is_descendant_of id="3" include_page="true" max_levels="1">
+	 * 			<ion:page:if_is_descendant_of id="3" include_page="true" max_levels="1">
 	 * 				This will be displayed if given id (3) is an id_page of a 1st level ancestor (parent actually) of the page, or the id of the page
-	 * 			</ion:page:tag_if_is_descendant_of>
+	 * 			</ion:page:if_is_descendant_of>
 	 *
-	 * 			<ion:page:tag_if_is_descendant_of ids="3,18">
+	 * 			<ion:page:if_is_descendant_of ids="3,18">
 	 * 				This will be displayed if one of the given ids (3,18) is an id_page of an ancestor of the page, but not the id of the page
-	 * 			</ion:page:tag_if_is_descendant_of>
+	 * 			</ion:page:if_is_descendant_of>
 	 */
 	public static function tag_if_is_descendant_of(FTL_Binding $tag)
 	{

--- a/application/models/page_model.php
+++ b/application/models/page_model.php
@@ -517,6 +517,67 @@ class Page_model extends Base_model
 
 
 	/**
+	 * Get page IDs of descendant pages of given page,
+	 * returns array of page IDs, optionally including the ID of the given page,
+	 * traversal depth can be limited / max_levels: 0 = infinite
+	 *
+	 * @param	int		$id_page			Predecessor page ID
+	 * @param	bool 	$include_id_page	Include predecessor page ID?
+	 * @param	int 	$current_level
+	 * @param	int 	$max_levels			How many ancestry page levels to go down? 0= infinite
+	 * @return	array	page IDs
+	 */
+	public function get_descendant_ids($id_page, $include_id_page=FALSE, $current_level, $max_levels = 0, $lang = NULL)
+	{
+		$ids = $include_id_page ? array($id_page) : array();
+
+		$child_ids = $this->get_children_ids($id_page, FALSE, FALSE);
+
+		if($max_levels === 0 || $current_level <= $max_levels) {
+			$current_level++;
+
+			foreach ($child_ids as $id_child) {
+				$ids[] = $id_child;
+
+				if($max_levels === 0 || $current_level < $max_levels) {
+					$ids = array_merge($ids, $this->get_descendant_ids($id_child, FALSE, $current_level, $max_levels, $lang, $current_level));
+				}
+			}
+		}
+
+		return array_unique($ids);
+	}
+
+
+	// ------------------------------------------------------------------------
+
+
+	/**
+	 * @param	array	$ancestor_ids 	array of (int) page IDs
+	 * @param	int	$id_page
+	 * @param	bool	$include_page_id
+	 * @param	int	$max_levels
+	 * @return	bool	Is given page a descendant of given ancestor?
+	 */
+	public function is_ancestor_of($ancestor_ids, $id_page, $include_page_id = FALSE, $max_levels = 0)
+	{
+		if( $include_page_id && in_array($id_page, $ancestor_ids, FALSE) )
+			return true;
+
+		foreach($ancestor_ids as $id_page_ancestor) {
+			if( in_array($id_page, $this->get_descendant_ids($id_page_ancestor, $include_page_id, $max_levels)) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+
+	// ------------------------------------------------------------------------
+
+
+	/**
 	 * @param        $id_page
 	 * @param string $separator
 	 * @param null   $lang

--- a/application/models/page_model.php
+++ b/application/models/page_model.php
@@ -464,18 +464,19 @@ class Page_model extends Base_model
 
 
 	/**
-	 * Returns one page children array
+	 * Returns one page children array (by default infinitely recursive: including all children of children)
 	 *
-	 * @param	int		$id_page
+	 * @param	int	$id_page
 	 * @param	array	$data		Empty data array.
 	 * @param	string	$lang		Lang code
+	 * @param	bool	$recursive	Get also children of children? infinitely recursive
 	 * @return	array	Children pages array
 	 */
-	public function get_children_array($id_page, $data = array(), $lang = NULL)
+	public function get_children_array($id_page, $data = array(), $lang = NULL, $recursive = TRUE)
 	{
 		$children = $this->get_lang_list(array('id_parent' => $id_page), $lang);
 
-		if ( ! empty($children))
+		if ( $recursive && ! empty($children) )
 		{
 			foreach($children as $page)
 			{
@@ -490,17 +491,29 @@ class Page_model extends Base_model
 	}
 
 
-	public function get_children_ids($id_page, $including_id_page=FALSE)
+	// ------------------------------------------------------------------------
+
+
+	/**
+	 * @param	int		$id_page
+	 * @param	bool	$including_id_page
+	 * @param	bool	$recursive
+	 * @return	array
+	 */
+	public function get_children_ids($id_page, $including_id_page=FALSE, $recursive = TRUE)
 	{
 		$ids = $including_id_page == TRUE ? array($id_page) : array();
 
-		$children = $this->get_children_array($id_page);
+		$children = $this->get_children_array($id_page, array(), NULL, $recursive);
 
 		foreach($children as $page)
 			$ids[] = $page['id_page'];
 
 		return $ids;
 	}
+
+
+	// ------------------------------------------------------------------------
 
 
 	/**


### PR DESCRIPTION
Example usages:

&lt;ion:page:if_is_descendant_of id="3"&gt;
	This will be displayed if given id (3) is an id_page of any ancestor of the page, but not the id of the page
&lt;/ion:page:if_is_descendant_of&gt;

&lt;ion:page:if_is_descendant_of id="3" include_page="true"&gt;
This will be displayed if given id (3) is an id_page of any ancestor of the page, or the id of the page
&lt;/ion:page:if_is_descendant_of&gt;

&lt;ion:page:if_is_descendant_of id="3" include_page="true" max_levels="1"&gt;
	This will be displayed if given id (3) is an id_page of a 1st level ancestor (parent actually) of the page, or the id of the page
&lt;/ion:page:if_is_descendant_of&gt;

&lt;ion:page:if_is_descendant_of ids="3,18"&gt;
	This will be displayed if one of the given ids (3,18) is an id_page of an ancestor of the page, but not the id of the page
&lt;/ion:page:if_is_descendant_of&gt;