### PR TITLE
Bugfix: Article Tagmanager - get_articles() was fetching also offline…

### DIFF
--- a/application/libraries/Tagmanager/Article.php
+++ b/application/libraries/Tagmanager/Article.php
@@ -173,7 +173,9 @@ class TagManager_Article extends TagManager
 			}
 		}
 
-		// Get only articles from the detected page
+		// Get only (online) articles from the detected page
+		$where['page_article.online'] = 1;
+		
 		if ( ! empty($page))
 			$where['id_page'] = $page['id_page'];
 


### PR DESCRIPTION
… articles

This fixes the get_articles() query of the tagmanager (see also my previous workaround for this in #234)