### PR TITLE
Fixed Notice: FTL binding: "non-object" message

### DIFF
--- a/application/libraries/ftl/binding.php
+++ b/application/libraries/ftl/binding.php
@@ -87,7 +87,9 @@ class FTL_Binding
 	function __construct($context, $locals, $name, $attr, $block)
 	{
 		list($this->context, $this->locals, $this->name, $this->attr, $this->block) = array($context, $locals, $name, $attr, $block);
-		$this->globals = $context->globals;
+		if( is_object($context) ) {
+			$this->globals = $context->globals;
+		}
 	}
 	
 	/**


### PR DESCRIPTION
Calling tags manually, without FTL_Binding context, was throwing a "Trying to get property of non-object" notice.