### PR TITLE
text_helper: improved character limiter to keep html tags intact

### DIFF
--- a/system/helpers/text_helper.php
+++ b/system/helpers/text_helper.php
@@ -67,38 +67,18 @@ if ( ! function_exists('word_limiter'))
  * so the character count may not be exactly as specified.
  *
  * @access	public
- * @param	string
- * @param	integer
- * @param	string	the end character. Usually an ellipsis
+ * @param	string	$str
+ * @param	integer	$n
+ * @param	string	$end_char	the end character. Usually an ellipsis
  * @return	string
  */
 if ( ! function_exists('character_limiter'))
 {
 	function character_limiter($str, $n = 500, $end_char = '&#8230;')
 	{
-		if (strlen($str) < $n)
-		{
-			return $str;
-		}
-
-		$str = preg_replace("/\s+/", ' ', str_replace(array("\r\n", "\r", "\n"), ' ', $str));
-
-		if (strlen($str) <= $n)
-		{
-			return $str;
-		}
-
-		$out = "";
-		foreach (explode(' ', trim($str)) as $val)
-		{
-			$out .= $val.' ';
-
-			if (strlen($out) >= $n)
-			{
-				$out = trim($out);
-				return (strlen($out) == strlen($str)) ? $out : $out.$end_char;
-			}
-		}
+		return strlen($str) < $n
+			? $str
+			: truncateHtml($str, $n, $end_char, false, true);
 	}
 }
 
@@ -535,6 +515,120 @@ if ( ! function_exists('ellipsize'))
 		}
 
 		return $beg.$ellipsis.$end;
+	}
+}
+
+
+// ------------------------------------------------------------------------
+
+if ( ! function_exists('truncateHtml')) {
+	/**
+	 * truncateHtml can truncate a string up to a number of characters while preserving whole words and HTML tags
+	 *
+	 * @param string  $text         String to truncate.
+	 * @param integer $length       Length of returned string, including ellipsis.
+	 * @param string  $ending       Ending to be appended to the trimmed string.
+	 * @param boolean $exact        If false, $text will not be cut mid-word
+	 * @param boolean $considerHtml If true, HTML tags would be handled correctly
+	 *
+	 * @return string Trimmed string.
+	 */
+	function truncateHtml($text, $length = 100, $ending = '...', $exact = false, $considerHtml = true)
+	{
+		if( $considerHtml ) {
+			// if the plain text is shorter than the maximum length, return the whole text
+			if( strlen(preg_replace('/<.*?>/', '', $text)) <= $length ) {
+				return $text;
+			}
+			// splits all html-tags to scanable lines
+			preg_match_all('/(<.+?>)?([^<>]*)/s', $text, $lines, PREG_SET_ORDER);
+			$total_length = strlen($ending);
+			$open_tags = array();
+			$truncate = '';
+			foreach($lines as $line_matches) {
+				// if there is any html-tag in this line, handle it and add it (uncounted) to the output
+				if( ! empty($line_matches[ 1 ]) ) {
+					// if it's an "empty element" with or without xhtml-conform closing slash
+					if( preg_match('/^<(\s*.+?\/\s*|\s*(img|br|input|hr|area|base|basefont|col|frame|isindex|link|meta|param)(\s.+?)?)>$/is', $line_matches[ 1 ]) ) {
+						// do nothing
+						// if tag is a closing tag
+					}
+					else if( preg_match('/^<\s*\/([^\s]+?)\s*>$/s', $line_matches[ 1 ], $tag_matches) ) {
+						// delete tag from $open_tags list
+						$pos = array_search($tag_matches[ 1 ], $open_tags);
+						if( $pos !== false ) {
+							unset($open_tags[ $pos ]);
+						}
+						// if tag is an opening tag
+					}
+					else if( preg_match('/^<\s*([^\s>!]+).*?>$/s', $line_matches[ 1 ], $tag_matches) ) {
+						// add tag to the beginning of $open_tags list
+						array_unshift($open_tags, strtolower($tag_matches[ 1 ]));
+					}
+					// add html-tag to $truncated text
+					$truncate .= $line_matches[ 1 ];
+				}
+				// calculate the length of the plain text part of the line; handle entities as one character
+				$content_length = strlen(preg_replace('/&[0-9a-z]{2,8};|&#[0-9]{1,7};|[0-9a-f]{1,6};/i', ' ', $line_matches[ 2 ]));
+				if( $total_length + $content_length > $length ) {
+					// the number of characters which are left
+					$left = $length - $total_length;
+					$entities_length = 0;
+					// search for html entities
+					if( preg_match_all('/&[0-9a-z]{2,8};|&#[0-9]{1,7};|[0-9a-f]{1,6};/i', $line_matches[ 2 ], $entities, PREG_OFFSET_CAPTURE) ) {
+						// calculate the real length of all entities in the legal range
+						foreach($entities[ 0 ] as $entity) {
+							if( $entity[ 1 ] + 1 - $entities_length <= $left ) {
+								$left--;
+								$entities_length += strlen($entity[ 0 ]);
+							}
+							else {
+								// no more characters left
+								break;
+							}
+						}
+					}
+					$truncate .= substr($line_matches[ 2 ], 0, $left + $entities_length);
+					// maximum length is reached, so get off the loop
+					break;
+				}
+				else {
+					$truncate .= $line_matches[ 2 ];
+					$total_length += $content_length;
+				}
+				// if the maximum length is reached, get off the loop
+				if( $total_length >= $length ) {
+					break;
+				}
+			}
+		}
+		else {
+			if( strlen($text) <= $length ) {
+				return $text;
+			}
+			else {
+				$truncate = substr($text, 0, $length - strlen($ending));
+			}
+		}
+		// if the words shouldn't be cut in the middle...
+		if( ! $exact ) {
+			// ...search the last occurance of a space...
+			$spacePos = strrpos($truncate, ' ');
+			if( isset($spacePos) ) {
+				// ...and cut the text in this position
+				$truncate = substr($truncate, 0, $spacePos);
+			}
+		}
+		// add the defined ending to the text
+		$truncate .= $ending;
+		if( $considerHtml ) {
+			// close all unclosed html-tags
+			foreach($open_tags as $tag) {
+				$truncate .= '</' . $tag . '>';
+			}
+		}
+
+		return $truncate;
 	}
 }
 


### PR DESCRIPTION
added method: truncateHtml, and used it within character limiter. When using it now eg. when displaying search results, html tags of truncated articles are kept intact. (before this fix, such a truncation might have resulted in display of not closed tags, possibly displaying following content wrong as of automatical correction by the browser, or leading to incorrect html markup)