### PR TITLE
Extended media_download tag

### DIFF
--- a/application/libraries/Tagmanager/Media.php
+++ b/application/libraries/Tagmanager/Media.php
@@ -512,8 +512,8 @@ class TagManager_Media extends TagManager
 	 * Renders a link (or other HTML tag, eg. button) for downloading a file (the download file must be added as media to the article)
 	 *
 	 * @usage	<ion:media:download class="download" />
-	 * @usage	<ion:media:download tag="button" class="download" />
-	 * @usage	<ion:media:download label="Download Now" tag="button" class="download" />
+	 * @usage	<ion:media:download tag_name="button" class="download" />
+	 * @usage	<ion:media:download label="Download Now" tag_name="button" class="download" />
 	 *
 	 * @param FTL_Binding $tag
 	 * @return string


### PR DESCRIPTION
* made this also work from within custom content elements
* added optional tag_name attribute, to allow eg. rendering download link via html button element
* added optional label attribute, if not given: uses media filename
* commented more usage examples