### PR TITLE
Bugfix: single quote inside cms content breaks ftl

### DIFF
--- a/application/libraries/ftl/binding.php
+++ b/application/libraries/ftl/binding.php
@@ -490,7 +490,10 @@ class FTL_Binding
 				$data_array = $this->get('data');
 
 			if (is_array($data_array) && isset($data_array[$key]))
-				return $data_array[$key];
+			{
+				// ensure single quotes do not break parser eval
+				return str_replace('\'', '&#39;', $data_array[$key]);
+			}
 		}
 
 		return NULL;


### PR DESCRIPTION
converting all single quotes within cms content prevents the parser eval from crashing