### PR TITLE
Fix FTL_ArrayContext::register() array check

### DIFF
--- a/application/libraries/ftl/arraycontext.php
+++ b/application/libraries/ftl/arraycontext.php
@@ -96,7 +96,7 @@ class FTL_ArrayContext extends FTL_Context
 	{
 		if ( ! is_null($array))
 		{
-			if ( ! isset($this->{$array}))
+			if ( ! isset($this->{'_registry_'.$array}))
 				$this->{'_registry_'.$array} = new FTL_VarStack();
 
 			$this->{'_registry_'.$array}->{$key} = $value;


### PR DESCRIPTION
When adding multiple attributes in partial view tag all of them are discarded except the last one.
```
<ion:partial view="example_view" attr1="value" attr2="value"/>
```
If ion attribute tag is used inside partial view to retrieve attr1 the return value is null.
```
<ion:attr key="attr1"/>
```