### PR TITLE
Add support for helpers and functions in lang tag

### DIFF
--- a/application/libraries/Tagmanager.php
+++ b/application/libraries/Tagmanager.php
@@ -2468,6 +2468,10 @@ class TagManager
 
 			if ( ! $autolink)
 				return self::wrap($tag, $line);
+			
+			// Process helpers, functions etc.
+    			if($line != '#'.$key)
+                		$line = self::process_value($tag, $line);
 
 			return self::wrap($tag, auto_link($line, 'both', TRUE));
 		}


### PR DESCRIPTION
Update Tagamanager.php to add support for parsing helpers and functions in lang tag.

`<ion:lang key="foo" helper="texter_helper:character_limiter:10">`